### PR TITLE
KYAN-50 fix jumping content after double click on an anchor link in table of contents

### DIFF
--- a/applications/common/frontend/src/atomic-design-system/05-page/p.page/p.page.scss
+++ b/applications/common/frontend/src/atomic-design-system/05-page/p.page/p.page.scss
@@ -19,6 +19,12 @@
 @use 'src/atomic-design-system/03-organism/o.body-background' as
   o-body-background;
 
+$bulma-navbar-height: 3.25rem;
+
+html {
+  // this prevents jumping content when clicking on anchor link in table of contents (KYAN-50)
+  scroll-padding-top: $bulma-navbar-height;
+}
 
 body.lines {
   @include o-body-background.o-body-background--lines;


### PR DESCRIPTION
## Description
This PR fixes jumping content after double click on an anchor link in table of contents

## Motivation and Context
In blog post when a user double clicks on a link in table of contents, the content is jumping. To fix this we need to apply `scroll-padding-top` CSS property.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
