### PR TITLE
KYAN-55 fix big right margin on mobile when using code tag in rte

### DIFF
--- a/applications/common/frontend/src/atomic-design-system/01-atom/a.content.scss
+++ b/applications/common/frontend/src/atomic-design-system/01-atom/a.content.scss
@@ -26,6 +26,10 @@
   @extend .t-line-height--150;
   @extend .t-letter-spacing--default;
 
+  code {
+    word-break: break-word;
+  }
+
   strong {
     color: unset;
   }

--- a/applications/common/frontend/src/components/Container/Container.scss
+++ b/applications/common/frontend/src/components/Container/Container.scss
@@ -21,12 +21,12 @@
 @use 'src/atomic-design-system/00-token/t.breakpoint' as breakpoint;
 
 .container {
-  padding-left: map.get(spacing.$spacing-values, '2');
-  padding-right: map.get(spacing.$spacing-values, '2');
+  padding-left: var(--spacing-2);
+  padding-right: var(--spacing-2);
 
   @include breakpoint.media-breakpoint-large {
-    padding-left: map.get(spacing.$spacing-values, '0');
-    padding-right: map.get(spacing.$spacing-values, '0');
+    padding-left: var(--spacing-0);
+    padding-right: var(--spacing-0);
   }
 }
 

--- a/applications/common/frontend/src/components/Container/Container.scss
+++ b/applications/common/frontend/src/components/Container/Container.scss
@@ -20,6 +20,16 @@
 @use 'src/bulma-overwrite/variables' as spacing;
 @use 'src/atomic-design-system/00-token/t.breakpoint' as breakpoint;
 
+.container {
+  padding-left: map.get(spacing.$spacing-values, '2');
+  padding-right: map.get(spacing.$spacing-values, '2');
+
+  @include breakpoint.media-breakpoint-large {
+    padding-left: map.get(spacing.$spacing-values, '0');
+    padding-right: map.get(spacing.$spacing-values, '0');
+  }
+}
+
 .section > .container {
   padding-bottom: map.get(spacing.$spacing-values, '5_4');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix big right margin on mobile when using `<code>` tag in Rich Text Editor.

## Motivation and Context
On mobile the inline code snippet `<code>/apps/rte/extended/configuration/.content.json</code>` forces page width to grow which adds horizontal overflow. This PR fixes that behavior.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
