### PR TITLE
KYAN-71: Introduce experience fragments component

### DIFF
--- a/applications/blogs/backend/pom.xml
+++ b/applications/blogs/backend/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-blogs</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>kyanite-blogs-backend</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Blogs backend</name>
   <description>Contains blogs backend.</description>
 
@@ -140,7 +140,7 @@
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-common-backend</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/applications/blogs/pom.xml
+++ b/applications/blogs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>pl.ds.kyanite</groupId>
         <artifactId>kyanite-applications</artifactId>
-        <version>0.0.15-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/applications/common/backend/pom.xml
+++ b/applications/common/backend/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-common</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>kyanite-common-backend</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Common backend</name>
   <description>Contains application backend.</description>
 

--- a/applications/common/backend/src/main/resources/libs/kyanite/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/.content.json
@@ -1,5 +1,5 @@
 {
   "sling:resourceType": "ws:Application",
-  "components": ["common/components", "blogs/components"],
-  "templates": ["common/templates", "blogs/templates"]
+  "components": ["common/components", "blogs/components", "fragments/components"],
+  "templates": ["common/templates", "blogs/templates", "fragments/templates"]
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/templates/pagesspace/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/templates/pagesspace/.content.json
@@ -6,6 +6,7 @@
     "/libs/kyanite/common/templates/contactuspage",
     "/libs/kyanite/common/templates/structurepage",
     "/libs/kyanite/blogs/templates/articlepage",
-    "/libs/kyanite/blogs/templates/bloglistingpage"
+    "/libs/kyanite/blogs/templates/bloglistingpage",
+    "/libs/kyanite/fragments/templates/fragmentspage"
   ]
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/templates/structurepage/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/templates/structurepage/.content.json
@@ -8,6 +8,7 @@
     "/libs/kyanite/common/templates/contactuspage",
     "/libs/kyanite/common/templates/structurepage",
     "/libs/kyanite/blogs/templates/articlepage",
-    "/libs/kyanite/blogs/templates/bloglistingpage"
+    "/libs/kyanite/blogs/templates/bloglistingpage",
+    "/libs/kyanite/fragments/templates/fragmentspage"
   ]
 }

--- a/applications/common/frontend/pom.xml
+++ b/applications/common/frontend/pom.xml
@@ -20,12 +20,12 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-common</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>kyanite-common-frontend</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Common frontend</name>
   <description>Contains application frontend.</description>
 

--- a/applications/common/pom.xml
+++ b/applications/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>pl.ds.kyanite</groupId>
         <artifactId>kyanite-applications</artifactId>
-        <version>0.0.15-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/applications/extensions/kyanite-richtext/pom.xml
+++ b/applications/extensions/kyanite-richtext/pom.xml
@@ -21,12 +21,12 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-applications</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
   <artifactId>kyanite-richtext</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Extensions RTE extensions module</name>
   <description>RTE extensions module</description>
 

--- a/applications/extensions/kyanite-table-service/pom.xml
+++ b/applications/extensions/kyanite-table-service/pom.xml
@@ -19,13 +19,13 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-applications</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>kyanite-table-service</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Extensions Table Service</name>
   <description>Table Service module</description>
 

--- a/applications/extensions/kyanite-table-view/pom.xml
+++ b/applications/extensions/kyanite-table-view/pom.xml
@@ -19,13 +19,13 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-applications</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>kyanite-table-view</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Extensions Table View</name>
   <description>Table View module</description>
 

--- a/applications/extensions/pom.xml
+++ b/applications/extensions/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>pl.ds.kyanite</groupId>
         <artifactId>kyanite-applications</artifactId>
-        <version>0.0.15-SNAPSHOT</version>
+        <version>0.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>kyanite-extensions</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
     <name>Kyanite Components Project - Extensions</name>
     <description>Parent for extension modules.</description>
     <packaging>pom</packaging>

--- a/applications/fragments/README.md
+++ b/applications/fragments/README.md
@@ -1,0 +1,18 @@
+## Description:
+
+Module contains components introducing experience fragments logic.
+
+It allows to create fragments that are shared between many pages. Moreover, changes published in fragments would be available on destination pages without republishing them.
+
+## Requirements:
+
+It requires 
+
+```nginx configuration
+
+ssi on;
+
+```
+
+configured on nginx.
+

--- a/applications/fragments/backend/bnd.bnd
+++ b/applications/fragments/backend/bnd.bnd
@@ -1,0 +1,1 @@
+Sling-Bundle-Resources: /libs/kyanite/fragments

--- a/applications/fragments/backend/pom.xml
+++ b/applications/fragments/backend/pom.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2023 Dynamic Solutions
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>pl.ds.kyanite</groupId>
+    <artifactId>kyanite-fragments</artifactId>
+    <version>0.0.15-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>kyanite-fragments-backend</artifactId>
+  <version>0.0.15-SNAPSHOT</version>
+  <name>Kyanite Components Project - Fragments backend</name>
+  <description>Contains application backend.</description>
+
+  <properties>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.sling</groupId>
+        <artifactId>sling-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bnd-process</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>pl.ds.websight</groupId>
+      <artifactId>websight-fragments-registry</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.models.api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.annotation.versioning</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.metatype.annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>pl.ds.websight</groupId>
+      <artifactId>websight-rest-framework</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>pl.ds.websight</groupId>
+      <artifactId>websight-pages-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.testing.sling-mock.junit5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>pl.ds.websight</groupId>
+      <artifactId>websight-assets-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/applications/fragments/backend/pom.xml
+++ b/applications/fragments/backend/pom.xml
@@ -15,19 +15,17 @@
     limitations under the License.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-fragments</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>kyanite-fragments-backend</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Kyanite Components Project - Fragments backend</name>
   <description>Contains application backend.</description>
 

--- a/applications/fragments/backend/src/main/java/pl/ds/kyanite/fragments/components/models/ExperienceFragment.java
+++ b/applications/fragments/backend/src/main/java/pl/ds/kyanite/fragments/components/models/ExperienceFragment.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.fragments.components.models;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import lombok.Getter;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.api.resource.ValueMap;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+
+@Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
+public class ExperienceFragment {
+
+  @Inject
+  @Getter
+  private String resource;
+
+  @Getter
+  private Boolean validPage = false;
+
+  @Getter
+  private String pagePath;
+
+  @SlingObject
+  private ResourceResolver resourceResolver;
+
+  @PostConstruct
+  private void init() {
+    validPage = checkIfValidPage();
+    pagePath = preparePagePath();
+  }
+
+  private boolean checkIfValidPage() {
+    Resource pageResource = resourceResolver.getResource(resource);
+    if (pageResource != null) {
+      ValueMap valueMap = pageResource.getValueMap();
+      String primaryType = valueMap.get("jcr:primaryType", String.class);
+      return "ws:Page".equals(primaryType);
+    }
+    return false;
+  }
+
+  private String preparePagePath() {
+    String path = resource;
+
+    if (resource == null) {
+      return null;
+    }
+
+    if (resource.endsWith("/")) {
+      path = resource.substring(0, resource.length() - 1);
+    }
+
+    return path + ".html";
+  }
+
+}

--- a/applications/fragments/backend/src/main/java/pl/ds/kyanite/fragments/components/models/package-info.java
+++ b/applications/fragments/backend/src/main/java/pl/ds/kyanite/fragments/components/models/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Version("1.0.0")
+package pl.ds.kyanite.fragments.components.models;
+
+import org.osgi.annotation.versioning.Version;

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/fragment/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/fragment/.content.json
@@ -1,0 +1,5 @@
+{
+  "group": "Kyanite Components",
+  "sling:resourceType": "ws:Component",
+  "title": "Experience fragment"
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/fragment/dialog/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/fragment/dialog/.content.json
@@ -1,0 +1,16 @@
+{
+  "sling:resourceType": "wcm/dialogs/dialog",
+  "tabs": {
+    "sling:resourceType": "wcm/dialogs/components/tabs",
+    "generalTab": {
+      "sling:resourceType": "wcm/dialogs/components/tab",
+      "label": "General",
+      "resource": {
+        "sling:resourceType": "wcm/dialogs/components/pathpicker",
+        "rootPath": "/content",
+        "name": "resource",
+        "label": "Resource"
+      }
+    }
+  }
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/fragment/fragment.html
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/fragment/fragment.html
@@ -1,0 +1,28 @@
+<!--/*
+  ~
+  ~     Copyright (C) 2023 Dynamic Solutions
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License");
+  ~     you may not use this file except in compliance with the License.
+  ~     You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~     Unless required by applicable law or agreed to in writing, software
+  ~     distributed under the License is distributed on an "AS IS" BASIS,
+  ~     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and
+  ~     limitations under the License.
+  ~
+*/-->
+
+<sly data-sly-use.model="pl.ds.kyanite.fragments.components.models.ExperienceFragment"></sly>
+<sly data-sly-test="${model.validPage}">
+  <sly data-sly-test.editor="${!wcmmode.isDisabled}">
+    <sly data-sly-test="${model.validPage}" data-sly-resource="${model.resource @ requestAttributes = wcmmode.disabledModeAttribute}"></sly>
+  </sly>
+</sly>
+<sly data-sly-test="${!editor}">
+  <!--# block name="fail" --><!--# endblock -->
+  <!--# include virtual="${model.pagePath}" stub="fail" -->
+</sly>

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/page/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/page/.content.json
@@ -1,0 +1,7 @@
+{
+  "sling:resourceSuperType": "kyanite/common/components/page",
+  "group": ".hidden",
+  "sling:resourceType": "ws:Component",
+  "title": "Page",
+  "background": ""
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/page/dialog/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/page/dialog/.content.json
@@ -1,0 +1,3 @@
+{
+  "sling:resourceSuperType": "wcm/core/components/page/dialog"
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/page/page.html
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/components/page/page.html
@@ -1,0 +1,31 @@
+<!--/*
+  ~
+  ~     Copyright (C) 2023 Dynamic Solutions
+  ~
+  ~     Licensed under the Apache License, Version 2.0 (the "License");
+  ~     you may not use this file except in compliance with the License.
+  ~     You may obtain a copy of the License at
+  ~
+  ~         http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~     Unless required by applicable law or agreed to in writing, software
+  ~     distributed under the License is distributed on an "AS IS" BASIS,
+  ~     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~     See the License for the specific language governing permissions and
+  ~     limitations under the License.
+  ~
+*/-->
+
+<html data-sly-unwrap="${wcmmode.isDisabled}">
+  <sly data-sly-test="${!wcmmode.isDisabled}" data-sly-include="head.html"></sly>
+
+  <body data-sly-unwrap="${wcmmode.isDisabled}">
+    <div data-sly-unwrap="${wcmmode.isDisabled}" class="section">
+      <sly data-sly-resource="${'container' @ resourceType=properties.resourceType}"></sly>
+    </div>
+
+    <sly data-sly-test="${!wcmmode.isDisabled}">
+      <script src="/libs/kyanite/webroot/main.js"></script>
+    </sly>
+  </body>
+</html>

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentpage/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentpage/.content.json
@@ -1,0 +1,4 @@
+{
+  "sling:resourceType": "ws:PageTemplate",
+  "title": "Experience fragment page"
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentpage/initial/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentpage/initial/.content.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "ws:Page",
+  "jcr:content": {
+    "jcr:primaryType": "ws:PageContent",
+    "sling:resourceType": "kyanite/fragments/components/page",
+    "container": {"sling:resourceType": "kyanite/common/components/container"}
+  }
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentspage/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentspage/.content.json
@@ -1,0 +1,6 @@
+{
+  "sling:resourceType": "ws:PageTemplate",
+  "title": "Experience fragments",
+  "description": "Experience fragments",
+  "allowedChildren": ["/libs/kyanite/fragments/templates/fragmentpage"]
+}

--- a/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentspage/initial/.content.json
+++ b/applications/fragments/backend/src/main/resources/libs/kyanite/fragments/templates/fragmentspage/initial/.content.json
@@ -1,0 +1,8 @@
+{
+  "jcr:primaryType": "ws:Page",
+  "jcr:content": {
+    "jcr:primaryType": "ws:PageContent",
+    "sling:resourceType": "kyanite/fragments/components/page",
+    "container": {"sling:resourceType": "kyanite/common/components/container/fixedcontainer"}
+  }
+}

--- a/applications/fragments/backend/src/test/java/pl/ds/kyanite/fragments/components/models/ExperienceFragmentTest.java
+++ b/applications/fragments/backend/src/test/java/pl/ds/kyanite/fragments/components/models/ExperienceFragmentTest.java
@@ -1,0 +1,86 @@
+package pl.ds.kyanite.fragments.components.models;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(SlingContextExtension.class)
+class ExperienceFragmentTest {
+
+  private static final String PATH = "/content/fragments";
+  private final SlingContext context = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
+
+  @BeforeEach
+  public void init() {
+    context.addModelsForClasses(ExperienceFragment.class);
+    context.load().json(requireNonNull(
+        Thread.currentThread().getContextClassLoader().getResourceAsStream("fragment.json")), PATH);
+  }
+
+  @Test
+  void emptyFragment() {
+    ExperienceFragment model =
+        requireNonNull(requireNonNull(context.resourceResolver()).getResource(PATH + "/empty"))
+            .adaptTo(ExperienceFragment.class);
+
+    assertThat(model).isNotNull();
+    assertThat(model.getResource()).isNull();
+    assertThat(model.getValidPage()).isFalse();
+    assertThat(model.getPagePath()).isNull();
+  }
+
+  @Test
+  void validFragment() {
+    ExperienceFragment model =
+        requireNonNull(requireNonNull(context.resourceResolver()).getResource(PATH + "/with-valid-resource"))
+            .adaptTo(ExperienceFragment.class);
+
+    assertThat(model).isNotNull();
+    assertThat(model.getResource()).isEqualTo("/content/fragments/pages/fragments/fragment");
+    assertThat(model.getValidPage()).isTrue();
+    assertThat(model.getPagePath()).isEqualTo("/content/fragments/pages/fragments/fragment.html");
+  }
+
+  @Test
+  void validFragmentWithSlashAtResourcePath() {
+    ExperienceFragment model =
+        requireNonNull(requireNonNull(context.resourceResolver()).getResource(PATH + "/with-slash-at-the-end"))
+            .adaptTo(ExperienceFragment.class);
+
+    assertThat(model).isNotNull();
+    assertThat(model.getResource()).isEqualTo("/content/fragments/pages/fragments/fragment/");
+    assertThat(model.getValidPage()).isTrue();
+    assertThat(model.getPagePath()).isEqualTo("/content/fragments/pages/fragments/fragment.html");
+  }
+
+  @Test
+  void invalidResourceFragment() {
+    ExperienceFragment model =
+        requireNonNull(requireNonNull(context.resourceResolver()).getResource(PATH + "/with-invalid-resource"))
+            .adaptTo(ExperienceFragment.class);
+
+    assertThat(model).isNotNull();
+    assertThat(model.getResource()).isEqualTo("/content/fragments/pages/fragments/invalid");
+    assertThat(model.getValidPage()).isFalse();
+    assertThat(model.getPagePath()).isEqualTo("/content/fragments/pages/fragments/invalid.html");
+  }
+
+  @Test
+  void notExistingResourceFragment() {
+    ExperienceFragment model =
+        requireNonNull(requireNonNull(context.resourceResolver()).getResource(PATH + "/with-not-existing-resource"))
+            .adaptTo(ExperienceFragment.class);
+
+    assertThat(model).isNotNull();
+    assertThat(model.getResource()).isEqualTo("/content/fragments/pages/fragments/not-existing");
+    assertThat(model.getValidPage()).isFalse();
+    assertThat(model.getPagePath()).isEqualTo("/content/fragments/pages/fragments/not-existing.html");
+  }
+
+}

--- a/applications/fragments/backend/src/test/java/pl/ds/kyanite/fragments/components/models/ExperienceFragmentTest.java
+++ b/applications/fragments/backend/src/test/java/pl/ds/kyanite/fragments/components/models/ExperienceFragmentTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2023 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package pl.ds.kyanite.fragments.components.models;
 
 import static java.util.Objects.requireNonNull;

--- a/applications/fragments/backend/src/test/resources/fragment.json
+++ b/applications/fragments/backend/src/test/resources/fragment.json
@@ -1,0 +1,38 @@
+{
+  "empty": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kyanite/fragments/components/fragment"
+  },
+  "with-valid-resource": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kyanite/common/components/box",
+    "resource": "/content/fragments/pages/fragments/fragment"
+  },
+  "with-invalid-resource": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kyanite/common/components/box",
+    "resource": "/content/fragments/pages/fragments/invalid"
+  },
+  "with-not-existing-resource": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kyanite/common/components/box",
+    "resource": "/content/fragments/pages/fragments/not-existing"
+  },
+  "with-slash-at-the-end": {
+    "jcr:primaryType": "nt:unstructured",
+    "sling:resourceType": "kyanite/common/components/box",
+    "resource": "/content/fragments/pages/fragments/fragment/"
+  },
+  "pages": {
+    "jcr:primaryType": "nt:unstructured",
+    "fragments": {
+      "jcr:primaryType": "nt:unstructured",
+      "fragment": {
+        "jcr:primaryType": "ws:Page"
+      },
+      "invalid": {
+        "jcr:primaryType": "nt:unstructured"
+      }
+    }
+  }
+}

--- a/applications/fragments/pom.xml
+++ b/applications/fragments/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (C) 2023 Dynamic Solutions
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>pl.ds.kyanite</groupId>
+    <artifactId>kyanite-applications</artifactId>
+    <version>0.0.15-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>kyanite-fragments</artifactId>
+  <name>Kyanite Components Project - Fragments</name>
+  <description>Parent for fragments modules.</description>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>backend</module>
+  </modules>
+
+</project>

--- a/applications/fragments/pom.xml
+++ b/applications/fragments/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-applications</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -34,6 +34,7 @@
     <module>extensions</module>
     <module>common</module>
     <module>blogs</module>
+    <module>fragments</module>
   </modules>
 
   <properties>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/content/pom.xml
+++ b/content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kyanite-content</artifactId>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>kyanite-distribution</artifactId>
@@ -46,31 +46,31 @@
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-common-backend</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-blogs-backend</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-common-frontend</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-table-view</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <type>pom</type>
     </dependency>
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-richtext</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <type>pom</type>
     </dependency>
   </dependencies>

--- a/distribution/src/main/docker/nginx/default.conf
+++ b/distribution/src/main/docker/nginx/default.conf
@@ -15,17 +15,18 @@
 server {
     listen       80;
     index        homepage.html;
+    ssi          on;
 
     location /libs/kyanite/web_root {
         root   /usr/share/nginx/html;
     }
 
     location ~ (.html|/)$ {
-        root   /usr/share/nginx/html/content/bulma/pages;
+        root   /usr/share/nginx/html/content/kyanite/pages;
     }
 
     location / {
-        root   /usr/share/nginx/html/content/bulma;
+        root   /usr/share/nginx/html/content/kyanite;
     }
 
 }

--- a/distribution/src/main/features/kyanite-project.json
+++ b/distribution/src/main/features/kyanite-project.json
@@ -13,6 +13,10 @@
       "start-order": "25"
     },
     {
+      "id": "pl.ds.kyanite:kyanite-fragments-backend:${project.version}",
+      "start-order": "25"
+    },
+    {
       "id": "pl.ds.kyanite:kyanite-table-service:${project.version}",
       "start-order": "25"
     },

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>pl.ds.kyanite</groupId>
   <artifactId>kyanite</artifactId>
-  <version>0.0.15-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
 
   <name>Kyanite Components Project</name>
   <packaging>pom</packaging>

--- a/tests/content/pom.xml
+++ b/tests/content/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-tests</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tests/end-to-end/pom.xml
+++ b/tests/end-to-end/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite-tests</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -46,14 +46,14 @@
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-distribution</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <classifier>websight-cms-kyanite-project</classifier>
       <type>slingosgifeature</type>
     </dependency>
     <dependency>
       <groupId>pl.ds.kyanite</groupId>
       <artifactId>kyanite-tests-content</artifactId>
-      <version>0.0.15-SNAPSHOT</version>
+      <version>0.1.0-SNAPSHOT</version>
       <type>pom</type>
     </dependency>
   </dependencies>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>pl.ds.kyanite</groupId>
     <artifactId>kyanite</artifactId>
-    <version>0.0.15-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
## Description
Experience fragments allow reusing the same page fragment on many pages. Moreover, publication changes in experience fragments are propagated on all the pages that contain this fragment. 

## Motivation and Context
We would like to introduce the possibility of sharing the same fragment between pages.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
