### PR TITLE
WOS-529 hide carousel arrows when number of items is less or equal than 4

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/CarouselComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/CarouselComponent.java
@@ -33,6 +33,7 @@ public class CarouselComponent {
   private static final String RT_CAROUSEL_ITEM = "kyanite/common/components/carousel/carouselitem";
   private static final String PN_ELEMENTS_IN_ROW = "elementsInRow";
   private static final int ROW_SIZE = 12;
+  private static final int VISIBLE_ITEMS_COUNT = 4;
 
   @ChildResource
   private Resource desktop;
@@ -60,6 +61,10 @@ public class CarouselComponent {
 
   public Boolean getHasChildren() {
     return items != null && !items.isEmpty();
+  }
+
+  public Boolean isPaginationNeeded() {
+    return items.size() > VISIBLE_ITEMS_COUNT;
   }
 
   @PostConstruct

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/carousel/carousel.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/carousel/carousel.html
@@ -19,7 +19,7 @@
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.CarouselComponent">
   <div class="carousel">
     <sly data-sly-test="${model.hasChildren}">
-      <div class="buttons is-right">
+      <div data-sly-test="${model.paginationNeeded}" class="buttons is-right">
         <button class="button previous-page-button" disabled>
           <span class="icon">
             <i class="mdi mdi-arrow-left"></i>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hide arrows in carousel component when number of items is less or equal than 4.

## Motivation and Context
Arrows don't make sense in carousel when all items are visible on the first page.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
