### PR TITLE
[KYAN-105] If there is no metadata title property, then use page titl…

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head.html
@@ -19,7 +19,7 @@
 <head>
   <sly data-sly-include="head-start.html"></sly>
   <meta charset="UTF-8">
-  <title>${properties.title}</title>
+  <title>${properties.title ? properties.title : properties.jcr:title}</title>
   <meta data-sly-test.keywords="${properties.title}" name="keywords" content="${keywords}">
   <meta data-sly-test.description="${properties.description}" name="description"
         content="${description}">


### PR DESCRIPTION
…e in meta title tag

## Motivation and Context
In most cases we don't want to use the different title in the meta title tags, so let's not force copying the same value between title properties

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
