### PR TITLE
[KYAN-119] Handle external urls in the Navbar component

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/navbar/NavbarItemComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/navbar/NavbarItemComponent.java
@@ -16,8 +16,10 @@
 
 package pl.ds.kyanite.common.components.models.navbar;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
@@ -79,6 +81,17 @@ public class NavbarItemComponent {
   @Getter
   @Default(values = "mdi-home-outline")
   private String icon;
+
+  @Getter
+  private boolean isExternalUrl;
+
+  @PostConstruct
+  private void init() {
+    isExternalUrl =
+        StringUtils.isNotEmpty(url) && !(LinkUtil.isInternal(url, resource.getResourceResolver())
+            || LinkUtil.isAnchorLink(url));
+
+  }
 
   public String getUrl() {
     return LinkUtil.handleLink(url, resource.getResourceResolver());

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/LinkUtil.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/LinkUtil.java
@@ -61,8 +61,8 @@ public class LinkUtil {
     return addHtmlExtensionSuffixToLink(link);
   }
 
-  private static boolean isAnchorLink(String link) {
-    return link.startsWith(ANCHOR_LINK_PREFIX);
+  public static boolean isAnchorLink(String link) {
+    return StringUtils.startsWith(link, ANCHOR_LINK_PREFIX);
   }
 
   public static boolean isInternal(String link, ResourceResolver resourceResolver) {
@@ -89,14 +89,14 @@ public class LinkUtil {
   }
 
   public static Resource getResource(String link, ResourceResolver resourceResolver) {
-    if (link.startsWith(PUBLISHED)) {
+    if (StringUtils.startsWith(link, PUBLISHED)) {
       return resourceResolver.getResource(link.replaceFirst(PUBLISHED, CONTENT));
     }
     return resourceResolver.getResource(link);
   }
 
   public static boolean isPublished(String link) {
-    return link.startsWith(PUBLISHED);
+    return StringUtils.startsWith(link, PUBLISHED);
   }
 
   private static String getPrimaryType(Resource resource) {

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbardropdown/navbardropdown.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbardropdown/navbardropdown.html
@@ -27,7 +27,7 @@
 
     <div class="navbar-dropdown ${model.isBoxed ? 'is-boxed' : ''}">
       <sly data-sly-list.item="${model.items}">
-        <a class="navbar-item" href="${item.url}">
+        <a class="navbar-item ${item.isExternalUrl ? 'external-url' : ''}" href="${item.url}" target="{item.isExternalUrl ? '_blank' : ''">
           <sly data-sly-test="${model.addIcon && model.icon}">
             <sly data-sly-resource="${resource @ resourceType = 'kyanite/common/components/icon', requestAttributes = wcmmode.disabledModeAttribute}"></sly>
           </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbaritem/navbaritem.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbaritem/navbaritem.html
@@ -18,7 +18,7 @@
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.navbar.NavbarItemComponent">
   <sly data-sly-test="${model.type == 'link'}">
-    <a class="navbar-item" href="${model.url}">
+    <a class="navbar-item ${model.isExternalUrl ? 'external-url' : ''}" href="${model.url}" target="${model.isExternalUrl ? '_blank' : ''}">
         <sly data-sly-test="${model.addIcon && model.icon}">
           <sly data-sly-resource="${resource @ resourceType = 'kyanite/common/components/icon', requestAttributes = wcmmode.disabledModeAttribute}"></sly>
         </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmegadropdown/navbarmegadropdown.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmegadropdown/navbarmegadropdown.html
@@ -34,7 +34,7 @@
                     ${section.label}
                   </span>
                   <sly data-sly-list.item="${section.sectionItems}">
-                    <a class="navbar-item" href="${item.url}">
+                    <a class="navbar-item ${item.isExternalUrl ? 'external-url' : ''}" href="${item.url}" target="${item.isExternalUrl ? '_blank' : ''}">
                       ${item.label}
                     </a>
                   </sly>
@@ -44,7 +44,7 @@
             <sly data-sly-test="${column.type == 'highlights'}">
               <div class="column highlights-column">
                 <sly data-sly-list.highlight="${column.highlights}">
-                  <a class="navbar-item" href="${highlight.url}">
+                  <a class="navbar-item ${highlight.isExternalUrl ? 'external-url' : ''}" href="${highlight.url}" target="${highlight.isExternalUrl ? '_blank' : ''}">
                     ${highlight.label}
                   </a>
                 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmenu/navbarmenu.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmenu/navbarmenu.html
@@ -21,7 +21,7 @@
     <div class="navbar-menu ${model.metaNavigation ? 'has-navbar-top': ''}" id="navMenu">
       <div data-sly-test="${model.metaNavigation}" class="navbar-top">
         <sly data-sly-list.item="${model.metaNavigation}">
-          <a class="navbar-item" href="${item.url}">
+          <a class="navbar-item ${item.isExternalUrl ? 'external-url' : ''}" href="${item.url}" target="${item.isExternalUrl ? '_blank': ''}">
             ${item.label}
           </a>
         </sly>


### PR DESCRIPTION
Added external-url css class to navbar-item indicating redirections outside our domain

Open externalUrls in new tab of web-browser

## Description
NavbarItemComponent has a flag isExternalUrl indicating if it is internal or externalUrl.

Based on that flag class and link target is added to the navbar-items used in navigation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
