### PR TITLE
[KYAN-122] Column in NavbarMegaDropdownComponent can be expanded to 2…

### DIFF
--- a/applications/common/frontend/src/atomic-design-system/03-organism/o.navbar/o.navbar.scss
+++ b/applications/common/frontend/src/atomic-design-system/03-organism/o.navbar/o.navbar.scss
@@ -250,6 +250,26 @@ $color-navbar-link: var(--color-grey--900);
         overflow: hidden;
       }
 
+      .column-2 {
+        min-width: 40%;
+        width: 40%;
+      }
+
+      .column-3 {
+        min-width: 60%;
+        width: 60%;
+      }
+
+      .column-4 {
+        min-width: 80%;
+        width: 80%;
+      }
+
+      .column-5 {
+        min-width: 100%;
+        width: 100%;
+      }
+
       // reset navbar-item style
       .navbar-item {
         padding: 0;

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/navbar-megadropdown-columns/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/navbar-megadropdown-columns/.content.xml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:ws="http://ds.pl/websight" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+    jcr:primaryType="ws:Page">
+    <jcr:content
+        jcr:lastModified="{Date}2023-05-08T10:49:01.046Z"
+        jcr:lastModifiedBy="sling-package-install"
+        jcr:primaryType="ws:PageContent"
+        jcr:title="Navbar Mega Dropdown Columns"
+        sling:resourceType="kyanite/common/components/page"
+        ws:lastModified="{Date}2024-01-11T12:54:04.856Z"
+        ws:lastModifiedBy="wsadmin"
+        ws:lastPublishAction="Publish"
+        ws:lastPublished="{Date}2023-05-24T13:16:15.706Z"
+        ws:lastPublishedBy="wsadmin"
+        ws:template="/libs/kyanite/common/templates/articlepage"
+        description="\0"
+        navbarFixed="true"
+        navbarFixedPosition="has-navbar-fixed-top"
+        ogDescription="\0"
+        ogTitle="\0"
+        ogUrl="\0"
+        title="\0"
+        twitterDescription="\0"
+        twitterImageAlt="\0"
+        twitterSite="\0"
+        twitterTitle="\0">
+        <pagecontainer
+            jcr:primaryType="nt:unstructured"
+            sling:resourceType="kyanite/common/components/pagecontainer">
+            <navbar
+                jcr:primaryType="nt:unstructured"
+                sling:resourceType="kyanite/common/components/navbar"
+                fixedOption="is-fixed-top"
+                isTransparent="false"
+                variant="is-white">
+                <brand
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kyanite/common/components/navbar/navbarbrand"
+                    createBurger="true">
+                    <item
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kyanite/common/components/navbar/navbaritem"
+                        imageSrcType="asset"
+                        label="Brand"
+                        type="image">
+                        <image
+                            jcr:primaryType="nt:unstructured"
+                            alt="\0"
+                            assetReference="/content/kyanite-visual-tests/assets/WebSight logo - working.png"
+                            src="/content/kyanite-visual-tests/assets/WebSight logo - working.png"/>
+                    </item>
+                </brand>
+                <menu
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kyanite/common/components/navbar/navbarmenu">
+                    <end
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kyanite/common/components/navbar/navbarend">
+                        <navbaritem
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/common/components/navbar/navbaritem"
+                            imageSrcType="asset"
+                            label="Platform"/>
+                        <navbarmegadropdown
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/common/components/navbar/navbarmegadropdown"
+                            dropdownLabel="Product"
+                            hasArrow="true">
+                            <dropdownColumns jcr:primaryType="nt:unstructured">
+                                <_x0031_
+                                    jcr:primaryType="nt:unstructured"
+                                    hideColumn="false"
+                                    type="highlights">
+                                    <sections jcr:primaryType="nt:unstructured"/>
+                                    <highlights jcr:primaryType="nt:unstructured">
+                                        <_x0030_
+                                            jcr:primaryType="nt:unstructured"
+                                            label="Service Mesh"
+                                            url="/content/kyanite-visual-tests/pages/navbar-megadropdown-columns"/>
+                                        <_x0031_
+                                            jcr:primaryType="nt:unstructured"
+                                            label="Streaming Framework"
+                                            url="/content/kyanite-visual-tests/pages/blog-listing"/>
+                                    </highlights>
+                                </_x0031_>
+                                <_x0032_
+                                    jcr:primaryType="nt:unstructured"
+                                    hideColumn="true"
+                                    type="text">
+                                    <sections jcr:primaryType="nt:unstructured">
+                                        <_x0030_
+                                            jcr:primaryType="nt:unstructured"
+                                            label="Overview">
+                                            <sectionItems jcr:primaryType="nt:unstructured">
+                                                <_x0030_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Real-time composability"
+                                                    url="https://www.websight.io/use-cases.html"/>
+                                                <_x0031_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="EDS: build or buy"
+                                                    url="https://www.websight.io/use-cases.html"/>
+                                                <_x0032_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Use cases"
+                                                    url="https://www.websight.io/use-cases.html"/>
+                                                <_x0033_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="FAQ"
+                                                    url="/content/kyanite-visual-tests/pages/card-full-height-variant"/>
+                                            </sectionItems>
+                                        </_x0030_>
+                                    </sections>
+                                </_x0032_>
+                                <_x0033_
+                                    jcr:primaryType="nt:unstructured"
+                                    hideColumn="false"
+                                    type="text">
+                                    <sections jcr:primaryType="nt:unstructured">
+                                        <_x0030_
+                                            jcr:primaryType="nt:unstructured"
+                                            label="Connectors">
+                                            <sectionItems jcr:primaryType="nt:unstructured">
+                                                <_x0030_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Edge Delivery Services"
+                                                    url="/content/kyanite-visual-tests/pages/heading-typography"/>
+                                                <_x0031_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="CommerceTools"
+                                                    url="https://commercetools.com/"/>
+                                                <_x0032_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Adobe Experience Manager"
+                                                    url="/content/kyanite-visual-tests/pages/level-item--feature-small"/>
+                                                <_x0033_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Adobe Commerce"
+                                                    url="https://commercetools.com/"/>
+                                                <_x0034_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Connectors Roadmap"
+                                                    url="https://commercetools.com"/>
+                                            </sectionItems>
+                                        </_x0030_>
+                                    </sections>
+                                </_x0033_>
+                                <_x0034_
+                                    jcr:primaryType="nt:unstructured"
+                                    hideColumn="true"
+                                    type="text">
+                                    <sections jcr:primaryType="nt:unstructured">
+                                        <_x0030_
+                                            jcr:primaryType="nt:unstructured"
+                                            label="Native CMS">
+                                            <sectionItems jcr:primaryType="nt:unstructured">
+                                                <_x0030_
+                                                    jcr:primaryType="nt:unstructured"
+                                                    label="Websight"
+                                                    url="https://www.websight.io"/>
+                                            </sectionItems>
+                                        </_x0030_>
+                                    </sections>
+                                </_x0034_>
+                                <_x0035_
+                                    jcr:primaryType="nt:unstructured"
+                                    hideColumn="true"
+                                    type="text"/>
+                            </dropdownColumns>
+                        </navbarmegadropdown>
+                        <navbaritem_1
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/common/components/navbar/navbaritem"
+                            imageSrcType="asset"
+                            label="Resources"/>
+                        <navbaritem_2
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/common/components/navbar/navbaritem"
+                            imageSrcType="asset"
+                            label="Architecture"/>
+                        <navbaritem_3
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/common/components/navbar/navbaritem"
+                            imageSrcType="asset"
+                            label="Pricing"/>
+                        <item
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/common/components/navbar/navbaritem"
+                            imageSrcType="asset"
+                            label="Item"
+                            type="container">
+                            <button
+                                jcr:primaryType="nt:unstructured"
+                                sling:resourceType="kyanite/common/components/button"
+                                label="Book a demo!"/>
+                        </item>
+                    </end>
+                    <metaNavigation jcr:primaryType="nt:unstructured">
+                        <_x0030_
+                            jcr:primaryType="nt:unstructured"
+                            label="About"
+                            url="https://www.websight.io/about/company.html"/>
+                        <_x0031_
+                            jcr:primaryType="nt:unstructured"
+                            label="Partners"
+                            url="https://www.websight.io/about/contact-us.html"/>
+                        <_x0032_
+                            jcr:primaryType="nt:unstructured"
+                            label="Contact"
+                            url="https://www.websight.io/about/company.html"/>
+                    </metaNavigation>
+                </menu>
+            </navbar>
+        </pagecontainer>
+    </jcr:content>
+</jcr:root>

--- a/tests/end-to-end/backstop.js
+++ b/tests/end-to-end/backstop.js
@@ -64,6 +64,10 @@ const scenarios = [
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label))
   },
+  { space: 'kyanite-visual-tests', page: 'navbar-megadropdown-columns', selectors: [selectors.body],
+    hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
+    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label))
+  },
   { space: 'kyanite-visual-tests', page: 'blog-article-header/blog-article-page', selectors: [selectors.container] },
   { space: 'kyanite-visual-tests', page: 'blog-listing', selectors: [selectors.container] },
   { space: 'kyanite-visual-tests', page: 'blog-article-author-bio', selectors: [selectors.content] },


### PR DESCRIPTION
…-5 columns width.

Update menu nav to show items wider than one column.

## Description
Add possibility to display columns wider. From 1 to 5 columns.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [X] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
