### PR TITLE
WSIO-397 fix button and card footer colors

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/card.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/card.html
@@ -46,12 +46,14 @@
       </div>
     </sly>
 
-    <footer class="card-footer">
-      <sly data-sly-list.url="${model.urls}">
-        <sly data-sly-test="${url.label}">
-          <a href="${url.address}" class="card-footer-item">${url.label}</a>
+    <sly data-sly-test="${model.urls}">
+      <footer class="card-footer">
+        <sly data-sly-list.url="${model.urls}">
+          <sly data-sly-test="${url.label}">
+            <a href="${url.address}" class="card-footer-item">${url.label}</a>
+          </sly>
         </sly>
-      </sly>
-    </footer>
+      </footer>
+    </sly>
   </div>
 </sly>

--- a/applications/common/frontend/src/atomic-design-system/01-atom/a.button.scss
+++ b/applications/common/frontend/src/atomic-design-system/01-atom/a.button.scss
@@ -92,8 +92,8 @@
     color: var(--base-color-body-text, var(--color-grey--900));
 
     &:hover {
-      border-color: var(--color-secondary--600, var(--color-primary--600));
-      color: var(--color-secondary--900, var(--color-primary--900));
+      background-color: var(--color-secondary--600, var(--color-primary--600));
+      border-color:     var(--color-secondary--600, var(--color-primary--600));
     }
 
     &:focus:not(:active) {

--- a/applications/common/frontend/src/atomic-design-system/01-atom/a.button.scss
+++ b/applications/common/frontend/src/atomic-design-system/01-atom/a.button.scss
@@ -72,6 +72,17 @@
     &.is-inverted {
       color: var(--color-primary--600);
     }
+
+    &.is-outlined {
+      background-color: transparent;
+      color:            var(--color-primary--600);
+      border-color:     var(--color-primary--600);
+
+      &:hover {
+        background-color: var(--color-primary--600);
+        border-color:     var(--color-primary--600);
+      }
+    }
   }
 
   &-secondary {

--- a/applications/common/frontend/src/atomic-design-system/02-molecule/m.card/m.card.scss
+++ b/applications/common/frontend/src/atomic-design-system/02-molecule/m.card/m.card.scss
@@ -24,4 +24,14 @@
     color: var(--color-grey--900);
   }
 
+  .card-footer {
+    border-top-color: var(--base-color-contrast-background, #ededed);
+
+    .card-footer-item {
+
+      &:not(:last-child) {
+        border-right-color: var(--base-color-contrast-background, #ededed);
+      }
+    }
+  }
 }


### PR DESCRIPTION
For dark-mode, changes of colours were applied for:
- outlined button text, background, borders
- secondary button button text, background, borders _**on hover**_
- card footer borders

## Description

## Motivation and Context

## Screenshots (if appropriate)
**Outlined button:**
Before: 
<img width="333" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/b062f87b-831e-4476-8c2a-63ece0009d85">
<img width="333" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/7a2a9627-2af6-4efd-81b5-c65f3083ae2e">

After:
<img width="333" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/2f05ebd5-e473-43ff-b1e3-b97ebdb793f8">
<img width="333" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/f999028d-6857-437a-b0af-8b73a160cd9f">

**Secondary button**:
Before:
![image](https://github.com/websight-io/kyanite/assets/13979207/aab19894-6410-4c39-a3fa-a424af7ef599)
After:
![image](https://github.com/websight-io/kyanite/assets/13979207/5a04f6f4-2fe3-4eed-ac10-98b5a4b25870)

**Card footer:**
Before:
![image](https://github.com/websight-io/kyanite/assets/13979207/67cd3359-8df3-48db-b4db-67e7f14cdd64)
After:
![image](https://github.com/websight-io/kyanite/assets/13979207/21e24d34-0128-4bc3-bf37-2b898f20f459)


## Upgrade notes (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
