### PR TITLE
WSIO-397 change content secondary text color

### DIFF
--- a/applications/common/frontend/src/atomic-design-system/01-atom/a.content.scss
+++ b/applications/common/frontend/src/atomic-design-system/01-atom/a.content.scss
@@ -35,7 +35,7 @@
   }
 
   strong {
-    color: unset;
+    color: var(--base-color-content-strong, unset);
   }
 
   &-xs {

--- a/applications/common/frontend/src/dark-mode/atomic-design-system/00-token/t.color/t.color.scss
+++ b/applications/common/frontend/src/dark-mode/atomic-design-system/00-token/t.color/t.color.scss
@@ -22,6 +22,7 @@ $map_t-base-color: (
   secondary-background: #232323,
   secondary-text: #AAA,
   contrast-background: #555,
+  content-strong: #03dac6,
   contrast-text: #CCC
 );
 


### PR DESCRIPTION
For content component _in dark mode_, **strong** text colour was changed. In the requirements, target text type is referenced to as 'secondary', but it is actually simple bold text, so the changes may affect text colouring in unexpected places. For that reason, PR should be considered experimental or temporary, until we come up with a better idea (which may include restructuring/reauthoring the content).

Also, the specific colour requested by the designer ( #03dac6 ) doesn't match any of existing secondary colours in _dark-mode/atomic-design-system/00-token/t.color/t.color.scss_ , so a new variable was introduced.

## Description
Reference: [Figma](https://www.figma.com/file/dPzhtXnsOK0T4x5RfEf6fE/StreamX-pages?type=design&node-id=1-2102&mode=design&t=XmCyHAFuZbjYKqe0-0)

Before:
<img width="433" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/b8e71988-254a-4b4f-9d5e-3e071b30fe80">

Required result (from reference):
<img width="371" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/d6b50135-7505-4143-bc85-28a2d1a29d11">

## Motivation and Context

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
