### PR TITLE
WSIO-397 code fixes contact form

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/contactform/contactform.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/contactform/contactform.html
@@ -81,7 +81,7 @@
 
     <div class="field">
       <div class="control">
-        <input id="submit-btn" class="button is-link is-medium" type="submit"
+        <input id="submit-btn" class="button is-primary is-medium" type="submit"
                value="${model.submitLabel}" data-form-id="${resource.name}">
       </div>
     </div>

--- a/applications/common/frontend/src/bulma-overwrite/colors.scss
+++ b/applications/common/frontend/src/bulma-overwrite/colors.scss
@@ -188,15 +188,44 @@
   }
 }
 
+/* anchor */
+
+a {
+  color: var(--color-primary--600);
+  &:hover {
+    color: var(--base-color-secondary-text);
+  }
+}
+
 /*  inputs text colors */
 
 .input, .select select, .textarea, .label  {
   color: var(--base-color-body-text, var(--color-grey--700));
-  background-color: var(--base-color-secondary-background, var(--base-color-white));
+  background-color: var(--base-color-body-background, var(--base-color-white));
+  &:focus, &:active, &.is-active, &.is-focused {
+    border-color: var(--color-primary--600);
+    box-shadow: none;
+  }
 }
 
-.input::placeholder {
+.select:not(.is-multiple):not(.is-loading):after {
+  border-color: var(--color-primary--600);
+}
+
+.input::placeholder, .textarea::placeholder {
   color: var(--base-color-secondary-text, var(--color-grey--700));
+}
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover, 
+input:-webkit-autofill:focus, 
+input:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 30px var(--base-color-body-background) inset;
+    -webkit-text-fill-color: var(--base-color-body-text);
+}
+
+input[type=checkbox] {
+  accent-color: var(--color-primary--600);
 }
 
 .checkbox:hover, .radio:hover {

--- a/applications/common/frontend/src/bulma-overwrite/colors.scss
+++ b/applications/common/frontend/src/bulma-overwrite/colors.scss
@@ -193,7 +193,7 @@
 a {
   color: var(--color-primary--600);
   &:hover {
-    color: var(--base-color-secondary-text);
+    color: var(--base-color-secondary-text, inherit);
   }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adjust contact form to support custom colors.

**One change will have effect on all kyanite-sites, and it is changing appearance of the focus state in inputs and texfields: As we don't use rgb values in color variables, it is impossible to make box-shadow as customised value (original bulma design has box-shadow with opacity - rgba value).  I skip this value and set box-shadow: none;**
Before:
<img width="690" alt="Screenshot 2024-02-27 at 15 16 31" src="https://github.com/websight-io/kyanite/assets/120561838/0c02d2ad-9283-44c1-a931-0a66f6bd2490">
After:
<img width="678" alt="Screenshot 2024-02-27 at 15 15 44" src="https://github.com/websight-io/kyanite/assets/120561838/31dbd68f-44c8-4491-9722-cc1fc089b2ef">



## Motivation and Context
streamx site requierement

## Screenshots (if appropriate)
Before:
<img width="813" alt="Screenshot 2024-02-27 at 15 22 36" src="https://github.com/websight-io/kyanite/assets/120561838/269efb6e-6569-4384-8e50-d6397e30fb9d">
After:
<img width="836" alt="Screenshot 2024-02-27 at 15 20 04" src="https://github.com/websight-io/kyanite/assets/120561838/075c6ba0-d16e-44b8-a86e-e85fa2516029">


## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
