### PR TITLE
KYAN-195 Enhance Section component to act like a Hero component

### DIFF
--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
@@ -12,6 +12,7 @@
       },
       "section": {
         "sling:resourceType": "kyanite/common/components/section",
+        "renderAsHero": "false",
         "container": {
           "sling:resourceType": "kyanite/common/components/container",
           "columns1": {

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/bloglistingpage/initial/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/bloglistingpage/initial/.content.json
@@ -13,6 +13,7 @@
       },
       "section": {
         "sling:resourceType": "kyanite/common/components/section",
+        "renderAsHero": "false",
         "container": {
           "sling:resourceType": "kyanite/common/components/container",
           "featuredblogarticle": {

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/HeroComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/HeroComponent.java
@@ -16,6 +16,7 @@
 
 package pl.ds.kyanite.common.components.models;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 import javax.annotation.PostConstruct;
@@ -24,6 +25,8 @@ import lombok.Getter;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.Self;
+import pl.ds.kyanite.common.components.utils.ContainerComponentUtil;
 
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
 public class HeroComponent {
@@ -44,11 +47,18 @@ public class HeroComponent {
   @Getter
   private String[] heroClasses;
 
+  @Self
+  private Resource resource;
+
+  @Getter
+  private List<Resource> children;
+
   @PostConstruct
   private void init() {
     heroClasses = Stream.of(size, variant, background)
         .filter(Objects::nonNull)
         .toList()
         .toArray(new String[]{});
+    children = ContainerComponentUtil.listVisibleChildren(resource);
   }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/SectionComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/SectionComponent.java
@@ -17,7 +17,6 @@
 package pl.ds.kyanite.common.components.models;
 
 import java.util.List;
-import java.util.stream.StreamSupport;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import lombok.Getter;
@@ -31,6 +30,7 @@ import org.apache.sling.models.annotations.injectorspecific.Self;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import pl.ds.kyanite.common.components.models.background.ComponentWithBackground;
 import pl.ds.kyanite.common.components.models.background.DefaultComponentWithBackground;
+import pl.ds.kyanite.common.components.utils.ContainerComponentUtil;
 
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
 public class SectionComponent implements ComponentWithBackground {
@@ -48,21 +48,19 @@ public class SectionComponent implements ComponentWithBackground {
   private String id;
 
   @Getter
-  List<Resource> children;
+  private List<Resource> children;
 
   @Self
   @Delegate
   private DefaultComponentWithBackground componentWithBackground;
 
+  @Inject
+  @Getter
+  private boolean renderAsHero;
+
   @PostConstruct
   void init() {
-    children = findValidItems();
+    children = ContainerComponentUtil.listVisibleChildren(resource);
   }
 
-  private List<Resource> findValidItems() {
-    return StreamSupport.stream(resource.getChildren().spliterator(), false)
-        //Image is defined on dialog level and should not be displayed in as separate component
-        .filter(res -> !StringUtils.equals("nt:unstructured", res.getResourceType()))
-        .toList();
-  }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/ContainerComponentUtil.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/ContainerComponentUtil.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.utils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+
+public class ContainerComponentUtil {
+
+  public static List<Resource> listVisibleChildren(final Resource resource) {
+    if (resource == null) {
+      return Collections.emptyList();
+    } else {
+      return StreamSupport.stream(resource.getChildren().spliterator(), false)
+          //E.g. Image is defined on dialog level and should not be displayed as separate component
+          .filter(res -> !StringUtils.equals("nt:unstructured", res.getResourceType()))
+          .toList();
+    }
+  }
+
+  private ContainerComponentUtil() {
+    // no instance
+  }
+}
+

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/hero/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/hero/.content.json
@@ -1,7 +1,7 @@
 {
   "isContainer": true,
   "isLayout": true,
-  "group": "Kyanite Layouts",
+  "group": ".Kyanite Layouts",
   "allowedComponents": [
     "Kyanite Columns",
     "Kyanite Components",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/hero/hero.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/hero/hero.html
@@ -1,6 +1,6 @@
 <!--/*
   ~
-  ~     Copyright (C) 2023 Dynamic Solutions
+  ~     Copyright (C) 2024 Dynamic Solutions
   ~
   ~     Licensed under the Apache License, Version 2.0 (the "License");
   ~     you may not use this file except in compliance with the License.
@@ -16,19 +16,19 @@
   ~
 */-->
 
-<sly data-sly-use.model="pl.ds.kyanite.common.components.models.HeroComponent">
-  <sly data-sly-set.classes="hero ${model.heroClasses @ join=' '}"></sly>
-  <sly data-sly-test="${resource.hasChildren}">
+<sly data-sly-use.model="pl.ds.kyanite.common.components.models.HeroComponent"
+     data-sly-set.classes="hero ${model.heroClasses @ join=' '}">
+  <sly data-sly-test="${model.children}">
     <section class="${classes}">
       <div class="hero-body">
-        <sly data-sly-list="${resource.children}">
-          <sly data-sly-resource="${item}"></sly>
+        <sly data-sly-list.child="${model.children}">
+          <sly data-sly-resource="${child.path @ resourceType=child.resourceType}"></sly>
         </sly>
       </div>
     </section>
   </sly>
 </sly>
-<sly data-sly-test="${!resource.hasChildren}">
+<sly data-sly-test="${!model.children}">
   <sly data-sly-use.lib="/libs/wcm/foundation/components/commons/templates.html"
        data-sly-call="${lib.placeholder @ classes=classes}"></sly>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/dialog/.content.json
@@ -1,6 +1,6 @@
 {
-  "sling:resourceType": "wcm/dialogs/dialog",
-  "tabs": {
+	"sling:resourceType": "wcm/dialogs/dialog",
+	"tabs": {
 		"sling:resourceType": "wcm/dialogs/components/tabs",
 		"generalTab": {
 			"sling:resourceType": "wcm/dialogs/components/tab",
@@ -14,11 +14,65 @@
 			"size": {
 				"sling:resourceType": "wcm/dialogs/components/include",
 				"path": "/libs/kyanite/common/components/hero/attributes/size"
+			},
+			"ws:display": {
+				"condition": {
+					"sourceName": "renderAsHero",
+					"values": "false"
+				}
 			}
 		},
 		"backgroundImage": {
 			"sling:resourceType": "wcm/dialogs/components/include",
-			"path": "/libs/kyanite/common/components/common/backgroundimage"
+			"path": "/libs/kyanite/common/components/common/backgroundimage",
+			"ws:display": {
+				"condition": {
+					"sourceName": "renderAsHero",
+					"values": "false"
+				}
+			}
+		},
+		"heroTab": {
+			"sling:resourceType": "wcm/dialogs/components/tab",
+			"label": "Hero General",
+			"size": {
+				"sling:resourceType": "wcm/dialogs/components/include",
+				"path": "/libs/kyanite/common/components/hero/attributes/size"
+			},
+			"variant": {
+				"sling:resourceType": "wcm/dialogs/components/include",
+				"path": "kyanite/common/components/hero/attributes/variant"
+			},
+			"background": {
+				"sling:resourceType": "wcm/dialogs/components/radio",
+				"name": "background",
+				"label": "Background",
+				"nobackground": {
+					"sling:resourceType": "wcm/dialogs/components/radio/option",
+					"label": "No background",
+					"value": ""
+				},
+				"circles": {
+					"sling:resourceType": "wcm/dialogs/components/radio/option",
+					"label": "Circles",
+					"value": "hero--bg-circles"
+				}
+			},
+			"ws:display": {
+				"condition": {
+					"sourceName": "renderAsHero",
+					"values": "true"
+				}
+			}
+		},
+		"variantSwitch": {
+			"sling:resourceType": "wcm/dialogs/components/tab",
+			"label": "Hero switch",
+			"switch": {
+				"sling:resourceType": "wcm/dialogs/components/toggle",
+				"name": "renderAsHero",
+				"label": "Is a hero banner?"
+			}
 		}
-  }
+	}
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/dialog/.content.json
@@ -1,78 +1,76 @@
 {
-	"sling:resourceType": "wcm/dialogs/dialog",
-	"tabs": {
-		"sling:resourceType": "wcm/dialogs/components/tabs",
-		"generalTab": {
-			"sling:resourceType": "wcm/dialogs/components/tab",
-			"label": "General",
-			"id": {
-				"sling:resourceType": "wcm/dialogs/components/textfield",
-				"name": "id",
-				"label": "Section id",
-				"required": true
-			},
-			"size": {
-				"sling:resourceType": "wcm/dialogs/components/include",
-				"path": "/libs/kyanite/common/components/hero/attributes/size"
-			},
-			"ws:display": {
-				"condition": {
-					"sourceName": "renderAsHero",
-					"values": "false"
-				}
-			}
-		},
-		"backgroundImage": {
-			"sling:resourceType": "wcm/dialogs/components/include",
-			"path": "/libs/kyanite/common/components/common/backgroundimage",
-			"ws:display": {
-				"condition": {
-					"sourceName": "renderAsHero",
-					"values": "false"
-				}
-			}
-		},
-		"heroTab": {
-			"sling:resourceType": "wcm/dialogs/components/tab",
-			"label": "Hero General",
-			"size": {
-				"sling:resourceType": "wcm/dialogs/components/include",
-				"path": "/libs/kyanite/common/components/hero/attributes/size"
-			},
-			"variant": {
-				"sling:resourceType": "wcm/dialogs/components/include",
-				"path": "kyanite/common/components/hero/attributes/variant"
-			},
-			"background": {
-				"sling:resourceType": "wcm/dialogs/components/radio",
-				"name": "background",
-				"label": "Background",
-				"nobackground": {
-					"sling:resourceType": "wcm/dialogs/components/radio/option",
-					"label": "No background",
-					"value": ""
-				},
-				"circles": {
-					"sling:resourceType": "wcm/dialogs/components/radio/option",
-					"label": "Circles",
-					"value": "hero--bg-circles"
-				}
-			},
-			"ws:display": {
-				"condition": {
-					"sourceName": "renderAsHero",
-					"values": "true"
-				}
-			}
-		},
-		"variantSwitch": {
-			"sling:resourceType": "wcm/dialogs/components/tab",
-			"label": "Hero switch",
-			"switch": {
-				"sling:resourceType": "wcm/dialogs/components/toggle",
-				"name": "renderAsHero",
-				"label": "Is a hero banner?"
-			}
-		}
-	}
+  "sling:resourceType": "wcm/dialogs/dialog",
+  "tabs": {
+    "sling:resourceType": "wcm/dialogs/components/tabs",
+    "generalTab": {
+      "sling:resourceType": "wcm/dialogs/components/tab",
+      "label": "General",
+      "variantSwitch": {
+        "sling:resourceType": "wcm/dialogs/components/toggle",
+        "name": "renderAsHero",
+        "label": "Is a hero banner?"
+      },
+      "sectionGeneralOptions": {
+        "sling:resourceType": "wcm/dialogs/components/container",
+        "id": {
+          "sling:resourceType": "wcm/dialogs/components/textfield",
+          "name": "id",
+          "label": "Section id",
+          "required": true
+        },
+        "size": {
+          "sling:resourceType": "wcm/dialogs/components/include",
+          "path": "/libs/kyanite/common/components/hero/attributes/size"
+        },
+        "ws:display": {
+          "condition": {
+            "sourceName": "renderAsHero",
+            "values": "false"
+          }
+        }
+      },
+      "heroGeneralOptions": {
+        "sling:resourceType": "wcm/dialogs/components/container",
+        "size": {
+          "sling:resourceType": "wcm/dialogs/components/include",
+          "path": "/libs/kyanite/common/components/hero/attributes/size"
+        },
+        "variant": {
+          "sling:resourceType": "wcm/dialogs/components/include",
+          "path": "kyanite/common/components/hero/attributes/variant"
+        },
+        "background": {
+          "sling:resourceType": "wcm/dialogs/components/radio",
+          "name": "background",
+          "label": "Background",
+          "nobackground": {
+            "sling:resourceType": "wcm/dialogs/components/radio/option",
+            "label": "No background",
+            "value": ""
+          },
+          "circles": {
+            "sling:resourceType": "wcm/dialogs/components/radio/option",
+            "label": "Circles",
+            "value": "hero--bg-circles"
+          }
+        },
+        "ws:display": {
+          "condition": {
+            "sourceName": "renderAsHero",
+            "values": "true"
+          }
+        }
+      }
+    },
+    "backgroundImage": {
+      "sling:resourceType": "wcm/dialogs/components/include",
+      "path": "/libs/kyanite/common/components/common/backgroundimage",
+      "ws:display": {
+        "condition": {
+          "sourceName": "renderAsHero",
+          "values": "false"
+        }
+      }
+    }
+  }
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/section.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/section.html
@@ -1,6 +1,6 @@
 <!--/*
   ~
-  ~     Copyright (C) 2023 Dynamic Solutions
+  ~     Copyright (C) 2024 Dynamic Solutions
   ~
   ~     Licensed under the Apache License, Version 2.0 (the "License");
   ~     you may not use this file except in compliance with the License.
@@ -15,21 +15,32 @@
   ~     limitations under the License.
   ~
 */-->
-<sly data-sly-use.model="pl.ds.kyanite.common.components.models.SectionComponent">
-    <section class="section ${model.size} ${model.hasBackgroundImage && !model.asImg ? 'with-background-image' : ''}" id="${model.id}"
-             style="--desktop-background-image:${model.desktopBackgroundImage @ context='text'};--tablet-background-image:${model.tabletBackgroundImage @ context='text'};--mobile-background-image:${model.mobileBackgroundImage @ context='text'};">
-          
-             <picture data-sly-test="${model.asImg}">
-               <sly data-sly-test="${model.mobileBackgroundImage}">
-                 <source media="(max-width:767px)" srcset="${model.mobileImage @ context='text'}"/>
-               </sly>
-               <sly data-sly-test="${model.tabletBackgroundImage}">
-                 <source media="(max-width:1023px)" srcset="${model.tabletImage @ context='text'}"/>
-               </sly>
-           
-               <img width="${model.width}" height="${model.height}" class="img-as-bg" src="${model.desktopImage}" alt="${model.alt}">
-             </picture>
-        <sly data-sly-repeat.paragraph="${model.children}"
-             data-sly-resource="${paragraph.path @ resourceType=paragraph.resourceType}"></sly>
-    </section>
+<sly data-sly-use.model="pl.ds.kyanite.common.components.models.SectionComponent"></sly>
+
+<!--/* If it's not configured to be a 'Hero' component, render the current resource as 'Section' component. */-->
+<sly data-sly-test="${!model.renderAsHero}">
+  <section
+      class="section ${model.size} ${model.hasBackgroundImage && !model.asImg ? 'with-background-image' : ''}"
+      id="${model.id}"
+      style="--desktop-background-image:${model.desktopBackgroundImage @ context='text'};--tablet-background-image:${model.tabletBackgroundImage @ context='text'};--mobile-background-image:${model.mobileBackgroundImage @ context='text'};">
+
+    <picture data-sly-test="${model.asImg}">
+      <sly data-sly-test="${model.mobileBackgroundImage}">
+        <source media="(max-width:767px)" srcset="${model.mobileImage @ context='text'}"/>
+      </sly>
+      <sly data-sly-test="${model.tabletBackgroundImage}">
+        <source media="(max-width:1023px)" srcset="${model.tabletImage @ context='text'}"/>
+      </sly>
+
+      <img width="${model.width}" height="${model.height}" class="img-as-bg" src="${model.desktopImage}"
+           alt="${model.alt}">
+    </picture>
+    <sly data-sly-repeat.paragraph="${model.children}"
+         data-sly-resource="${paragraph.path @ resourceType=paragraph.resourceType}"></sly>
+  </section>
+</sly>
+
+<!--/* Render the current resource as 'Hero' if it's configured to be so. */-->
+<sly data-sly-test="${model.renderAsHero}">
+  <sly data-sly-resource="${currentResource.path @ resourceType='kyanite/common/components/hero'}"></sly>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/template/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/template/.content.json
@@ -2,5 +2,8 @@
 	"jcr:primaryType": "nt:unstructured",
 	"size": "is-normal",
 	"width": "1280",
-	"height": "720"
+	"height": "720",
+	"renderAsHero": "false",
+	"variant": "is-primary",
+	"background": ""
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/templates/homepage/initial/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/templates/homepage/initial/.content.json
@@ -47,6 +47,7 @@
       },
       "section": {
         "sling:resourceType": "kyanite/common/components/section",
+        "renderAsHero": "false",
         "container": {
           "sling:resourceType": "kyanite/common/components/container"
         }

--- a/content/src/main/content/jcr_root/content/kyanite/pages/Personal/.content.xml
+++ b/content/src/main/content/jcr_root/content/kyanite/pages/Personal/.content.xml
@@ -46,7 +46,8 @@
                             url="#about">
                             <hero
                                 jcr:primaryType="nt:unstructured"
-                                sling:resourceType="kyanite/common/components/hero"/>
+                                sling:resourceType="kyanite/common/components/section"
+                                renderAsHero="true"/>
                         </navbaritem>
                         <item_1
                             jcr:primaryType="nt:unstructured"
@@ -85,7 +86,8 @@
             </navbar>
             <hero
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/hero"
+                sling:resourceType="kyanite/common/components/section"
+                renderAsHero="true"
                 size="is-fullheight"
                 subTitle="\0"
                 title="\0"
@@ -119,6 +121,7 @@
             <section
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/section"
+                renderAsHero="false"
                 id="about">
                 <content
                     jcr:primaryType="nt:unstructured"
@@ -316,6 +319,7 @@
             <section_1
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/section"
+                renderAsHero="false"
                 id="services">
                 <content
                     jcr:primaryType="nt:unstructured"
@@ -385,6 +389,7 @@
             <section_1_1
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/section"
+                renderAsHero="false"
                 id="resume">
                 <content
                     jcr:primaryType="nt:unstructured"
@@ -415,6 +420,7 @@
             <section_1_1_1
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/section"
+                renderAsHero="false"
                 id="portfolio">
                 <content
                     jcr:primaryType="nt:unstructured"
@@ -1056,6 +1062,7 @@
             <section_1_1_2
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/section"
+                renderAsHero="false"
                 id="contact">
                 <content
                     jcr:primaryType="nt:unstructured"

--- a/distribution/src/main/groovy/0.4.19/hero_to_section.groovy
+++ b/distribution/src/main/groovy/0.4.19/hero_to_section.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This script changes the content structure of the link component
+ * what has two bunch for icons properties (right and left)
+ * For every bunch properties will be created as separate nodes
+ * and old properties will be removed.
+ */
+
+dryRun = true
+rootPaths = ['/content']
+updatedSectionsCount = 0
+convertedHeroesCount = 0
+
+def findSectionComponents(String rootPath) {
+    return resourceResolver.findResources("SELECT * FROM [nt:base] AS s WHERE ISDESCENDANTNODE([$rootPath]) AND" +
+            "[sling:resourceType]='kyanite/common/components/section'", "JCR-SQL2")
+}
+
+def findHeroComponents(String rootPath) {
+    return resourceResolver.findResources("SELECT * FROM [nt:base] AS s WHERE ISDESCENDANTNODE([$rootPath]) AND" +
+            "[sling:resourceType]='kyanite/common/components/hero'", "JCR-SQL2")
+}
+
+def setProperty(Resource res, String propertyName, String propertyValue) {
+    def vm = res.getValueMap()
+    def modifiableValueMap = res.adaptTo(org.apache.sling.api.resource.ModifiableValueMap)
+    modifiableValueMap.put(propertyName, propertyValue)
+}
+
+rootPaths.each {
+    rootPath ->
+        findSectionComponents(rootPath).each {
+            res ->
+                try {
+                    setProperty(res, "renderAsHero", "false")
+                    updatedSectionsCount++
+                } catch (Exception e) {
+                    println("Error processing resource: " + res.path + " with error: " + e.getMessage())
+                }
+        }
+
+        findHeroComponents(rootPath).each {
+            res ->
+                try {
+                    setProperty(res, "sling:resourceType", "kyanite/common/components/section")
+                    setProperty(res, "renderAsHero", "true")
+                    convertedHeroesCount++
+                } catch (Exception e) {
+                    println("Error processing resource: " + res.path + " with error: " + e.getMessage())
+                }
+        }
+}
+
+if (dryRun) {
+    println("Script in dryRun mode. Updated $updatedSectionsCount 'Section' component(s). Converted $convertedHeroesCount 'Hero' component(s) to 'Section' component(s).")
+} else {
+    println("Updated $updatedSectionsCount 'Section' component(s). Converted $convertedHeroesCount 'Hero' component(s) to 'Section' component(s).")
+    resourceResolver.commit()
+}

--- a/distribution/src/main/groovy/0.4.19/hero_to_section.groovy
+++ b/distribution/src/main/groovy/0.4.19/hero_to_section.groovy
@@ -22,6 +22,7 @@
  */
 
 dryRun = true
+final PN_HERO_SWITCH = "renderAsHero"
 rootPaths = ['/content']
 updatedSectionsCount = 0
 convertedHeroesCount = 0
@@ -36,6 +37,10 @@ def findHeroComponents(String rootPath) {
             "[sling:resourceType]='kyanite/common/components/hero'", "JCR-SQL2")
 }
 
+def hasProperty(Resource res, String propertyName) {
+    res.getValueMap().containsKey(propertyName)
+}
+
 def setProperty(Resource res, String propertyName, String propertyValue) {
     def vm = res.getValueMap()
     def modifiableValueMap = res.adaptTo(org.apache.sling.api.resource.ModifiableValueMap)
@@ -47,8 +52,12 @@ rootPaths.each {
         findSectionComponents(rootPath).each {
             res ->
                 try {
-                    setProperty(res, "renderAsHero", "false")
-                    updatedSectionsCount++
+                    // only update 'Section' components if they don't have the new property,
+                    // because subsequent executions of this script would also reconfigure 'Section' components which were a 'Hero' before
+                    if (!hasProperty(res, PN_HERO_SWITCH)) {
+                        setProperty(res, PN_HERO_SWITCH, "false")
+                        updatedSectionsCount++
+                    }
                 } catch (Exception e) {
                     println("Error processing resource: " + res.path + " with error: " + e.getMessage())
                 }
@@ -58,7 +67,7 @@ rootPaths.each {
             res ->
                 try {
                     setProperty(res, "sling:resourceType", "kyanite/common/components/section")
-                    setProperty(res, "renderAsHero", "true")
+                    setProperty(res, PN_HERO_SWITCH, "true")
                     convertedHeroesCount++
                 } catch (Exception e) {
                     println("Error processing resource: " + res.path + " with error: " + e.getMessage())

--- a/tests/content/src/main/content/jcr_root/content/kyanite-e2e-tests/pages/image/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-e2e-tests/pages/image/.content.xml
@@ -18,7 +18,7 @@
                     sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section">
+                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-e2e-tests/pages/section/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-e2e-tests/pages/section/.content.xml
@@ -12,7 +12,7 @@
       sling:resourceType="kyanite/common/components/pagecontainer">
       <section
         jcr:primaryType="nt:unstructured"
-        sling:resourceType="kyanite/common/components/section"/>
+        sling:resourceType="kyanite/common/components/section" renderAsHero="false"/>
     </pagecontainer>
   </jcr:content>
 </jcr:root>

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-article-author-bio/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-article-author-bio/.content.xml
@@ -32,7 +32,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-listing/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-listing/.content.xml
@@ -20,7 +20,7 @@
                 sling:resourceType="kyanite/common/components/container">
                 <section
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section">
+                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                     <featuredblogarticle
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="kyanite/blogs/components/featuredblogarticle"/>

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/icons/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/icons/.content.xml
@@ -19,7 +19,7 @@
             sling:resourceType="kyanite/common/components/pagecontainer">
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/level-item--feature/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/level-item--feature/.content.xml
@@ -18,7 +18,7 @@
             sling:resourceType="kyanite/common/components/pagecontainer">
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <feature
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/level/levelitem"

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/level/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/level/.content.xml
@@ -16,7 +16,7 @@
             sling:resourceType="kyanite/common/components/pagecontainer">
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <level_1
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/level">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/table-of-content/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/table-of-content/.content.xml
@@ -18,7 +18,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/table-of-content/table-of-content-no-title/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/table-of-content/table-of-content-no-title/.content.xml
@@ -30,7 +30,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/table-of-content/table-of-content/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/table-of-content/table-of-content/.content.xml
@@ -32,7 +32,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/tabs/tabs-layouts-and-styles/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/tabs/tabs-layouts-and-styles/.content.xml
@@ -20,7 +20,7 @@
                     sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section">
+                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-article-author-bio/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-article-author-bio/.content.xml
@@ -32,7 +32,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-listing/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-listing/.content.xml
@@ -20,7 +20,7 @@
                 sling:resourceType="kyanite/common/components/container">
                 <section
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section">
+                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                     <featuredblogarticle
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="kyanite/blogs/components/featuredblogarticle"/>

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/icons/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/icons/.content.xml
@@ -19,7 +19,7 @@
             sling:resourceType="kyanite/common/components/pagecontainer">
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/level-item--feature/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/level-item--feature/.content.xml
@@ -18,7 +18,7 @@
             sling:resourceType="kyanite/common/components/pagecontainer">
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <feature
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/level/levelitem"

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/level/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/level/.content.xml
@@ -16,7 +16,7 @@
             sling:resourceType="kyanite/common/components/pagecontainer">
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <level_1
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/level">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/table-of-content/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/table-of-content/.content.xml
@@ -18,7 +18,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/table-of-content/table-of-content-no-title/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/table-of-content/table-of-content-no-title/.content.xml
@@ -30,7 +30,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/table-of-content/table-of-content/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/table-of-content/table-of-content/.content.xml
@@ -32,7 +32,7 @@
                 sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/section">
+                sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="kyanite/common/components/container">

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/tabs/tabs-layouts-and-styles/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/tabs/tabs-layouts-and-styles/.content.xml
@@ -20,7 +20,7 @@
                     sling:resourceType="kyanite/common/components/navbarreference"/>
             <section
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section">
+                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                 <container
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="kyanite/common/components/container">

--- a/tests/end-to-end/tests/layouts/section.cy.ts
+++ b/tests/end-to-end/tests/layouts/section.cy.ts
@@ -60,6 +60,7 @@ describe('Section layout', function () {
     .should('deep.eq', {
       id: 'section1',
       size: 'is-halfheight',
+      renderAsHero: 'false',
       'sling:resourceType': 'kyanite/common/components/section',
       'jcr:primaryType': 'nt:unstructured'
     });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR introduces the following changes:
* Enhance 'Section' component to be able to rendered as a 'Hero' component
  * 'Hero' component is not removed physically (for downstream projects), but it's no more present within the list of available components
* Align E2E tests and test content to 'Section' changes
* Align templates and initial content to 'Section' changes
* Add Groovy content migration scripts

## Motivation and Context
We have two similar components that allow us to create a page section: Section and Hero.

We could merge those components into one (Section). It could have a toggle “Is a hero banner“. When it’s checked we can show Hero specific properties.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
Execute the Groovy content migration script *0.4.19/hero_to_section.groovy* in Groovy console to
* convert 'Hero' components to 'Section' components
* update 'Section' components with new property to have the edit dialog rendered properly

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
