### PR TITLE
KYAN-215 Add anchor option to Card component

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/CardComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/CardComponent.java
@@ -76,6 +76,19 @@ public class CardComponent implements ComponentWithBackground {
   @Default(values = StringUtils.EMPTY)
   private String heightVariant;
 
+  @Inject
+  @Getter
+  @Default(values = "card")
+  private String type;
+
+  @Inject
+  @Default(values = StringUtils.EMPTY)
+  private String anchorUrl;
+
+  @Inject
+  @Getter
+  private boolean openInNewTab;
+
   @SlingObject
   private Resource resource;
 
@@ -107,5 +120,9 @@ public class CardComponent implements ComponentWithBackground {
 
   public String getMobileAssetReference() {
     return LinkUtil.handleLink(mobileAssetReference, resourceResolver);
+  }
+
+  public String getAnchorUrl() {
+    return LinkUtil.handleLink(anchorUrl, resource.getResourceResolver());
   }
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/card.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/card.html
@@ -68,5 +68,9 @@
         </sly>
       </footer>
     </sly>
+
+    <sly data-sly-test="${model.type == 'anchor' && model.anchorUrl}">
+      <a class="card-redirect-anchor" href="${model.anchorUrl}" target="${model.openInNewTab ? '_blank' : ''}"></a>
+    </sly>
   </div>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/dialog/.content.json
@@ -25,6 +25,41 @@
           "label": "Full height",
           "value": "card--full-height"
         }
+      },
+      "type": {
+        "sling:resourceType": "wcm/dialogs/components/select",
+        "name": "type",
+        "label": "Type",
+        "card": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Card",
+          "value": "card"
+        },
+        "anchor": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Anchor",
+          "value": "anchor"
+        }
+      },
+      "container": {
+        "sling:resourceType": "wcm/dialogs/components/container",
+        "anchorUrl": {
+          "sling:resourceType": "wcm/dialogs/components/pathpicker",
+          "rootPath": "/content",
+          "name": "anchorUrl",
+          "label": "Anchor URL"
+        },
+        "openInNewTab": {
+          "sling:resourceType": "wcm/dialogs/components/toggle",
+          "name": "openInNewTab",
+          "label": "Open link in a new tab"
+        },
+        "ws:display": {
+          "condition": {
+            "sourceName": "type",
+            "values": "anchor"
+          }
+        }
       }
     },
     "imageTab": {

--- a/applications/common/frontend/src/components/Card/Card.scss
+++ b/applications/common/frontend/src/components/Card/Card.scss
@@ -31,4 +31,14 @@
   &.with-background-image {
     @extend .a-bg-image
   }
+
+  .card-redirect-anchor {
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    z-index: 3;
+    cursor: pointer;
+  }
 }


### PR DESCRIPTION
Add anchor option to Card component

## Description
Added the option of treating the Card as an anchor, being able to redirect the user on click to an internal or an external target.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
