### PR TITLE
KYAN-221 Allow components with group 'Kyanite In-Text Sections' only under other container components.

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/block/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/block/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Block"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/box/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/box/.content.json
@@ -4,7 +4,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "group": "Kyanite Elements",
   "sling:resourceType": "ws:Component",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/cardcontent/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/cardcontent/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Card Content"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/carousel/carouselitem/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/carousel/carouselitem/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Carousel item"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/column/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/column/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Single column"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/container/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/container/.content.json
@@ -6,7 +6,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Container"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/footer/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/footer/.content.json
@@ -6,7 +6,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Footer"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/layouts/socialproof/socialproofitem/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/layouts/socialproof/socialproofitem/.content.json
@@ -2,7 +2,7 @@
   "sling:resourceType": "ws:Component",
   "isContainer": true,
   "isLayout": true,
-  "group": "Kyanite Sections",
+  "group": "Kyanite In-Text Sections",
   "instanceResourceType": "kyanite/common/components/card",
   "title": "Social Proof - Item"
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/level/levelitem/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/level/levelitem/.content.json
@@ -4,7 +4,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "group": "Kyanite sub-components",
   "sling:resourceType": "ws:Component",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/mediacontent/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/mediacontent/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Media Content"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/medialeft/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/medialeft/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Media Left"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/mediaright/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/mediaright/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Media Right"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/modal/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/modal/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Modal"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/modalcard/modalcardcontent/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/modalcard/modalcardcontent/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Modal Card Content"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/modalcard/modalcardfooter/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/modalcard/modalcardfooter/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Modal Card Footer"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbaritem/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbaritem/.content.json
@@ -4,7 +4,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Navbar item",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/panel/panelblock/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/panel/panelblock/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Panel Block"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/.content.json
@@ -6,7 +6,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Section"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/tabs/tabcontent/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/tabs/tabcontent/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Tab Content"

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/tiles/tilechild/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/tiles/tilechild/.content.json
@@ -5,7 +5,8 @@
     "Kyanite Columns",
     "Kyanite Components",
     "Kyanite Elements",
-    "Kyanite Layouts"
+    "Kyanite Layouts",
+    "Kyanite In-Text Sections"
   ],
   "sling:resourceType": "ws:Component",
   "title": "Child tile"


### PR DESCRIPTION
## Description
This MR introduces the following changes:
* Change "Social Proof - Item" component's group to "Kyanite In-Text Sections"
* Allow components with group "Kyanite In-Text Sections" to be added under:
  * block
  * box
  * cardcontent
  * carouselitem
  * column
  * container
  * footer
  * levelitem
  * miediacontent
  * medialeft
  * mediaright
  * modal
  * modalcardcontent
  * modalcardfooter
  * navbaritem
  * panelblock
  * section
  * tabcontent
  * tilechild

## Motivation and Context
The author should be able to add layouts from the "Kyanite Sections" group to the page container only, and layouts from the "Kyanite In-Text Sections" group to all the other containers.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
