### PR TITLE
KYAN-194 Move components out of Layouts tab

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Columns",
   "allowedComponents": [
     "/apps/kyanite/common/components/columns/column",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/container/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/container/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Layouts",
   "allowedComponents": [
     "Kyanite Columns",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/footer/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/footer/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Layouts",
   "allowedComponents": [
     "Kyanite Columns",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/level/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/level/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Layouts",
   "allowedComponents": [
     "Level building blocks",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/mediaobject/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Layouts",
   "allowedComponents": [
     "/apps/kyanite/common/components/mediaobject/medialeft",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Layouts",
   "allowedComponents": [
     "Kyanite Columns",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/tiles/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/tiles/.content.json
@@ -1,6 +1,5 @@
 {
   "isContainer": true,
-  "isLayout": true,
   "group": "Kyanite Layouts",
   "allowedComponents": [
     "/apps/kyanite/common/components/tiles/tileparent",


### PR DESCRIPTION
Move components out of Layouts tab

## Description
The purpose of the Layouts tab is to keep predefined sections allowing authors to build pages fast, hence we are moving component groups like Kyanite Columns and Kyanite Layouts out from the Layouts tab.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
