### PR TITLE
KYAN-223 Restrict BlogArticlePage template

### DIFF
--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogPostBackButtonComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogPostBackButtonComponent.java
@@ -27,6 +27,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import pl.ds.kyanite.common.components.utils.LinkUtil;
 import pl.ds.websight.pages.core.api.Page;
 import pl.ds.websight.pages.core.api.PageManager;
@@ -45,6 +46,10 @@ public class BlogPostBackButtonComponent {
 
   @Getter
   private String link;
+
+  @ValueMapValue
+  @Getter
+  private boolean isHidden;
 
   @Inject
   public BlogPostBackButtonComponent(@SlingObject ResourceResolver resourceResolver,

--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogPostTableOfContentsComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogPostTableOfContentsComponent.java
@@ -28,6 +28,7 @@ import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import pl.ds.kyanite.common.components.models.TitleComponent;
 import pl.ds.websight.pages.core.api.Page;
 import pl.ds.websight.pages.core.api.PageManager;
@@ -38,6 +39,10 @@ public class BlogPostTableOfContentsComponent {
   private static final String BLOG_CONTENT_CONTAINER_REL_PATH =
       "/jcr:content/pagecontainer/section/container/columns1/column4";
   private static final String TITLE_RESOURCE_PATH = "kyanite/common/components/title";
+
+  @ValueMapValue
+  @Getter
+  private boolean isHidden;
 
   @Getter
   @Inject

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogpostbackbutton/blogpostbackbutton.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogpostbackbutton/blogpostbackbutton.html
@@ -17,8 +17,13 @@
 */-->
 
 <sly data-sly-use.model="pl.ds.kyanite.blogs.components.models.BlogPostBackButtonComponent">
-  <a href="${model.link}" class="blog-back-button">
-    <span class="mdi mdi-arrow-left"></span>
-    <span>All blog articles</span>
-  </a>
+  <sly data-sly-test="${model.isHidden && wcmmode.isEdit}">
+    <div class="blog-back-button-placeholder">This component will be hidden on the page.</div>
+  </sly>
+  <sly data-sly-test="${!model.isHidden}">
+    <a href="${model.link}" class="blog-back-button">
+      <span class="mdi mdi-arrow-left"></span>
+      <span>All blog articles</span>
+    </a>
+  </sly>
 </sly>

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogpostbackbutton/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogpostbackbutton/dialog/.content.json
@@ -1,0 +1,15 @@
+{
+  "sling:resourceType": "wcm/dialogs/dialog",
+  "tabs": {
+    "sling:resourceType": "wcm/dialogs/components/tabs",
+    "generalTab": {
+      "sling:resourceType": "wcm/dialogs/components/tab",
+      "label": "General",
+      "isHidden": {
+        "sling:resourceType": "wcm/dialogs/components/toggle",
+        "label": "Hide component?",
+        "name": "isHidden"
+      }
+    }
+  }
+}

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogposttableofcontents/blogposttableofcontents.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogposttableofcontents/blogposttableofcontents.html
@@ -17,26 +17,31 @@
 */-->
 
 <sly data-sly-use.model="pl.ds.kyanite.blogs.components.models.BlogPostTableOfContentsComponent">
-    <div data-sly-test="${model.items}" class="blog-table-of-content">
-        <label class="table-label">${model.title}</label>
-        <ul class="table-content-list">
-            <div data-sly-list.item="${model.items}" data-sly-unwrap>
-                <sly data-sly-test="${item.title}">
-                    <li class="button is-ghost table-content-list__item--${item.headingLevel}">
-                        <a class="" data-sly-attribute.href="#${item.url}">
-                            ${item.title}
-                        </a>
-                    </li>
-                </sly>
-            </div>
-        </ul>
-        <sly data-sly-test="${model.showBackToTopButton}">
-            <a class="table-content-button" data-sly-attribute.href="#">
-                <span class="table-content-button__label">
-                    <span class="mdi mdi-arrow-up"></span>
-                    <span>${model.backToTopButtonLabel}</span>
-                </span>
-            </a>
-        </sly>
-    </div>
+    <sly data-sly-test="${model.isHidden && wcmmode.isEdit}">
+        <div class="blog-back-button-placeholder">This component will be hidden on the page.</div>
+    </sly>
+    <sly data-sly-test="${!model.isHidden}">
+        <div data-sly-test="${model.items}" class="blog-table-of-content">
+            <label class="table-label">${model.title}</label>
+            <ul class="table-content-list">
+                <div data-sly-list.item="${model.items}" data-sly-unwrap>
+                    <sly data-sly-test="${item.title}">
+                        <li class="button is-ghost table-content-list__item--${item.headingLevel}">
+                            <a class="" data-sly-attribute.href="#${item.url}">
+                                ${item.title}
+                            </a>
+                        </li>
+                    </sly>
+                </div>
+            </ul>
+            <sly data-sly-test="${model.showBackToTopButton}">
+                <a class="table-content-button" data-sly-attribute.href="#">
+                    <span class="table-content-button__label">
+                        <span class="mdi mdi-arrow-up"></span>
+                        <span>${model.backToTopButtonLabel}</span>
+                    </span>
+                </a>
+            </sly>
+        </div>
+    </sly>
 </sly>

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogposttableofcontents/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogposttableofcontents/dialog/.content.json
@@ -5,6 +5,11 @@
     "generalTab": {
       "sling:resourceType": "wcm/dialogs/components/tab",
       "label": "General",
+      "isHidden": {
+        "sling:resourceType": "wcm/dialogs/components/toggle",
+        "label": "Hide component?",
+        "name": "isHidden"
+      },
       "title": {
         "sling:resourceType": "wcm/dialogs/components/textfield",
         "label": "Title",

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
@@ -15,16 +15,16 @@
         "sling:resourceType": "kyanite/common/components/navbarreference"
       },
       "section": {
-        "sling:resourceType": "kyanite/common/components/section",
+        "sling:resourceType": "kyanite/common/components/section/fixedsection",
         "renderAsHero": "false",
         "container": {
-          "sling:resourceType": "kyanite/common/components/container",
+          "sling:resourceType": "kyanite/common/components/container/fixedcontainer",
           "columns1": {
-            "sling:resourceType": "kyanite/common/components/columns",
+            "sling:resourceType": "kyanite/common/components/columns/fixedcolumns",
             "columnsActivationLevel": "is-desktop",
             "isMultiline": "true",
             "column1": {
-              "sling:resourceType": "kyanite/common/components/columns/column",
+              "sling:resourceType": "kyanite/common/components/columns/column/fixedcolumn",
               "customClass": "sticky-container",
               "desktopColumnStyle": {
                 "jcr:primaryType": "nt:unstructured",
@@ -50,7 +50,7 @@
               }
             },
             "column2": {
-              "sling:resourceType": "kyanite/common/components/columns/column",
+              "sling:resourceType": "kyanite/common/components/columns/column/fixedcolumn",
               "desktopColumnStyle": {
                 "jcr:primaryType": "nt:unstructured",
                 "size": "eight",
@@ -78,7 +78,7 @@
               }
             },
             "column3": {
-              "sling:resourceType": "kyanite/common/components/columns/column",
+              "sling:resourceType": "kyanite/common/components/columns/column/fixedcolumn",
               "customClass": "sticky-container",
               "desktopColumnStyle": {
                 "jcr:primaryType": "nt:unstructured",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/column/fixedcolumn/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/column/fixedcolumn/.content.json
@@ -1,0 +1,7 @@
+{
+  "group": ".hidden",
+  "isContainer": false,
+  "sling:resourceType": "ws:Component",
+  "sling:resourceSuperType": "kyanite/common/components/columns/column",
+  "title": "Fixed Single Column"
+}

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/fixedcolumns/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/fixedcolumns/.content.json
@@ -1,0 +1,7 @@
+{
+  "group": ".hidden",
+  "isContainer": false,
+  "sling:resourceType": "ws:Component",
+  "sling:resourceSuperType": "kyanite/common/components/columns",
+  "title": "Fixed Columns"
+}

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/fixedsection/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/fixedsection/.content.json
@@ -1,0 +1,7 @@
+{
+  "group": ".hidden",
+  "isContainer": false,
+  "sling:resourceType": "ws:Component",
+  "sling:resourceSuperType": "kyanite/common/components/section",
+  "title": "Fixed Section"
+}

--- a/distribution/src/main/groovy/0.4.19/fix_blogarticlepages.groovy
+++ b/distribution/src/main/groovy/0.4.19/fix_blogarticlepages.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This script handles the already existing instances of blogarticlepages
+ * after the changes in KYAN-223. In these changes, the majority of
+ * components in the template becomes fixed to prevent deleting them
+ * and thus breaking the page. Also fixes the structure of already
+ * broken instances.
+ */
+
+dryRun = true
+rootPaths = ['/content']
+resourceTypeProperty = 'sling:resourceType'
+fixedSectionPath = 'kyanite/common/components/section/fixedsection'
+fixedContainerPath = 'kyanite/common/components/container/fixedcontainer'
+fixedColumnsPath = 'kyanite/common/components/columns/fixedcolumns'
+fixedColumnPath = 'kyanite/common/components/columns/column/fixedcolumn'
+newColumnProperties = ['jcr:primaryType': 'nt:unstructured', 'sling:resourceType': fixedColumnPath, 'customClass': 'sticky-container']
+backButtonProperties = ['jcr:primaryType': 'nt:unstructured', 'sling:resourceType': 'kyanite/blogs/components/blogpostbackbutton', 'isHidden': 'true']
+tableOfContentsProperties = ['jcr:primaryType': 'nt:unstructured', 'sling:resourceType': 'kyanite/blogs/components/blogposttableofcontents', 'maxHeadingLevel': '2', 'isHidden': 'true']
+updatedPagesCount = 0
+
+def findBlogArticlePageInstances(String rootPath) {
+    return resourceResolver.findResources("SELECT * FROM [nt:base] AS s WHERE ISDESCENDANTNODE([$rootPath]) " +
+            "AND [sling:resourceType]='kyanite/blogs/components/blogarticlepage'", "JCR-SQL2")
+}
+
+def hasChild(Resource parentResource, String childName) {
+    parentResource.getChild(childName) != null
+}
+
+def createColumnWithContent(Resource columnsResource, String columnName, LinkedHashMap contentProperties, String contentNodeName, String followingColumnName) {
+    resourceResolver.create(columnsResource, columnName, newColumnProperties)
+    def newColumnResource = columnsResource.getChild(columnName)
+    resourceResolver.create(newColumnResource, contentNodeName, contentProperties)
+    def columnsNode = columnsResource.adaptTo(javax.jcr.Node)
+    columnsNode.orderBefore(columnName, followingColumnName)
+}
+
+def modifyResourceTypes(Resource parentResource, String childResourceName, String newResourceType) {
+    def childResource = parentResource.getChild(childResourceName)
+    childResource.adaptTo(org.apache.sling.api.resource.Resource)
+    def childResourceMVM = childResource.adaptTo(org.apache.sling.api.resource.ModifiableValueMap)
+    childResourceMVM.replace(resourceTypeProperty, newResourceType)
+    return childResource
+}
+
+def addAndModifyContent(Resource resource) {
+    def pageContainerResource = resource.getChild('pagecontainer')
+    def sectionResource = modifyResourceTypes(pageContainerResource, 'section', fixedSectionPath)
+    def containerResource = modifyResourceTypes(sectionResource, 'container', fixedContainerPath)
+    def columnsResource = modifyResourceTypes(containerResource, 'columns1', fixedColumnsPath)
+
+    if(hasChild(columnsResource, 'column1')) {
+        def column1Resource = modifyResourceTypes(columnsResource, 'column1', fixedColumnPath)
+        if (!hasChild(column1Resource, 'backbutton')) {
+            def columnNode = column1Resource.adaptTo(javax.jcr.Node)
+            columnNode.remove()
+            createColumnWithContent(columnsResource, 'column1', backButtonProperties, 'backbutton', 'column2')
+        }
+    } else {
+        createColumnWithContent(columnsResource, 'column1', backButtonProperties, 'backbutton', 'column2')
+    }
+
+    modifyResourceTypes(columnsResource, 'column2', fixedColumnPath)
+
+    if(hasChild(columnsResource, 'column3')) {
+        def column3Resource = modifyResourceTypes(columnsResource, 'column3', fixedColumnPath)
+        if (!hasChild(column3Resource, 'blogposttableofcontents')) {
+            def columnNode = column3Resource.adaptTo(javax.jcr.Node)
+            columnNode.remove()
+            createColumnWithContent(columnsResource, 'column3', tableOfContentsProperties, 'blogposttableofcontents', 'column4')
+        }
+    } else {
+        createColumnWithContent(columnsResource, 'column3', tableOfContentsProperties, 'blogposttableofcontents', 'column4')
+    }
+}
+
+rootPaths.each {
+    rootPath ->
+        findBlogArticlePageInstances(rootPath).each {
+            res ->
+                try {
+                    addAndModifyContent(res)
+                    updatedPagesCount++
+                } catch (Exception e) {
+                    println("Error processing resource: " + res.path + " with error: " + e.getMessage())
+                }
+        }
+}
+
+if (dryRun) {
+    println("Script in dryRun mode. Updated $updatedPagesCount 'BlogArticlePage' instance(s).")
+} else {
+    println("Updated $updatedPagesCount 'BlogArticlePage' instance(s).")
+    resourceResolver.commit()
+}


### PR DESCRIPTION
Apply restrictions on BlogArticlePage template to prevent breaking the pages created based on that.

## Description
- added fixed versions of Section, Columns and Column components to prevent modifications on them
- updated the BlogArticlePage template with the fixed components
- modified BlogPostBackButton and BlogPostTableOfContents to be able to hide them from the published page using a toggle on the dialog
- added a Groovy script to modify the already existing instances, and apart from updating resource types, it handles:
  - pages where the Single Column components of navigations were removed
  - columns where the navigation components were removed from the specific columns

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
