### PR TITLE
Feature/KYAN-146 config store refactoring

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/ContactFormConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/ContactFormConfigStore.java
@@ -16,6 +16,7 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface ContactFormConfigStore {
-  ContactFormConfiguration get(String spaceName);
+import pl.ds.kyanite.common.components.services.config.ConfigStore;
+
+public interface ContactFormConfigStore extends ConfigStore<ContactFormConfiguration> {
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/ContactFormConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/ContactFormConfiguration.java
@@ -16,9 +16,9 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface ContactFormConfiguration {
-  String getSpaceName();
+import pl.ds.kyanite.common.components.services.config.SpaceDependentConfiguration;
 
+public interface ContactFormConfiguration extends SpaceDependentConfiguration {
   String getConfigEndpoint();
 
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/ContactFormConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/ContactFormConfiguration.java
@@ -19,6 +19,7 @@ package pl.ds.kyanite.common.components.services;
 import pl.ds.kyanite.common.components.services.config.SpaceDependentConfiguration;
 
 public interface ContactFormConfiguration extends SpaceDependentConfiguration {
+
   String getConfigEndpoint();
 
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/CookieModalConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/CookieModalConfigStore.java
@@ -16,6 +16,7 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface CookieModalConfigStore {
-  CookieModalConfiguration get(String spaceName);
+import pl.ds.kyanite.common.components.services.config.ConfigStore;
+
+public interface CookieModalConfigStore extends ConfigStore<CookieModalConfiguration> {
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/CookieModalConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/CookieModalConfiguration.java
@@ -16,8 +16,9 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface CookieModalConfiguration {
-  String getSpaceName();
+import pl.ds.kyanite.common.components.services.config.SpaceDependentConfiguration;
+
+public interface CookieModalConfiguration extends SpaceDependentConfiguration {
 
   String getPrivacyPolicyPath();
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/GoogleAnalyticsConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/GoogleAnalyticsConfigStore.java
@@ -16,6 +16,7 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface GoogleAnalyticsConfigStore {
-  GoogleAnalyticsConfiguration get(String spaceName);
+import pl.ds.kyanite.common.components.services.config.ConfigStore;
+
+public interface GoogleAnalyticsConfigStore extends ConfigStore<GoogleAnalyticsConfiguration> {
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/GoogleAnalyticsConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/GoogleAnalyticsConfiguration.java
@@ -16,9 +16,9 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface GoogleAnalyticsConfiguration {
+import pl.ds.kyanite.common.components.services.config.SpaceDependentConfiguration;
 
-  String getSpaceName();
+public interface GoogleAnalyticsConfiguration extends SpaceDependentConfiguration {
 
   String getGoogleAnalyticsTrackingId();
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfig.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfig.java
@@ -19,6 +19,7 @@ package pl.ds.kyanite.common.components.services;
 import pl.ds.kyanite.common.components.services.config.ServiceConfiguration;
 
 public interface LibraryIconConfig extends ServiceConfiguration {
+
   String getLabel();
 
   String getLibraryUrl();

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfig.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfig.java
@@ -16,10 +16,10 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface LibraryIconConfig {
-  String getLabel();
+import pl.ds.kyanite.common.components.services.config.ServiceConfiguration;
 
-  String getId();
+public interface LibraryIconConfig extends ServiceConfiguration {
+  String getLabel();
 
   String getLibraryUrl();
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfigStore.java
@@ -20,5 +20,7 @@ import java.util.List;
 import pl.ds.kyanite.common.components.services.config.ConfigStore;
 
 public interface LibraryIconConfigStore extends ConfigStore<LibraryIconConfig> {
+
   List<LibraryIconConfig> getAllConfigs();
+
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/LibraryIconConfigStore.java
@@ -17,9 +17,8 @@
 package pl.ds.kyanite.common.components.services;
 
 import java.util.List;
+import pl.ds.kyanite.common.components.services.config.ConfigStore;
 
-public interface LibraryIconConfigStore {
-  LibraryIconConfig get(String id);
-
+public interface LibraryIconConfigStore extends ConfigStore<LibraryIconConfig> {
   List<LibraryIconConfig> getAllConfigs();
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/RecaptchaConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/RecaptchaConfigStore.java
@@ -16,6 +16,7 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface RecaptchaConfigStore {
-  RecaptchaConfiguration get(String spaceName);
+import pl.ds.kyanite.common.components.services.config.ConfigStore;
+
+public interface RecaptchaConfigStore extends ConfigStore<RecaptchaConfiguration> {
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/RecaptchaConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/RecaptchaConfiguration.java
@@ -16,8 +16,9 @@
 
 package pl.ds.kyanite.common.components.services;
 
-public interface RecaptchaConfiguration {
-  String getSpaceName();
+import pl.ds.kyanite.common.components.services.config.SpaceDependentConfiguration;
+
+public interface RecaptchaConfiguration extends SpaceDependentConfiguration {
 
   String getCaptchaPublicKey();
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/BaseConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/BaseConfigStore.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class containing common logic of binding/unbinding/retrieving service configurations by id.
+ *
+ * @param <T> class extending ServiceConfiguration.
+ *           The later must return unique id to be associated with in the config store
+ */
+
+public abstract class BaseConfigStore<T extends ServiceConfiguration> implements ConfigStore<T> {
+
+  protected List<T> configsList = new ArrayList<>();
+
+  @Override
+  public T get(String id) {
+    for (T confFact : configsList) {
+      if (id.equals(confFact.getId())) {
+        return confFact;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public synchronized void bind(T config) {
+    if (configsList == null) {
+      configsList = new ArrayList<>();
+    }
+    configsList.add(config);
+  }
+
+  @Override
+  public synchronized void unbind(final T config) {
+    configsList.remove(config);
+  }
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/BaseSpaceDependentConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/BaseSpaceDependentConfigStore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+import org.apache.sling.api.resource.Resource;
+import pl.ds.kyanite.common.components.utils.PagesSpaceUtil;
+
+/**
+ * Config store retrieving space dependent configurations by space name.
+ *
+ * @param <T> class implementing SpaceDependentConfiguration.
+ *           Space name from the configuration serves as ID in this case.
+ *           Space name or a resource consuming the configuration is resolved by that resource path
+ */
+
+public abstract class BaseSpaceDependentConfigStore<T extends SpaceDependentConfiguration>
+    extends     BaseConfigStore<T>
+    implements  SpaceDependentConfigStore<T> {
+
+  @Override
+  public T get(Resource resource) {
+    String spaceName = PagesSpaceUtil.getWsPagesSpaceName(resource.getPath(),
+        resource.getResourceResolver());
+    return get(spaceName);
+  }
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/BaseSpaceDependentConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/BaseSpaceDependentConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+
+public abstract class BaseSpaceDependentConfiguration implements SpaceDependentConfiguration {
+
+  protected String spaceName;
+
+  @Override
+  public String getSpaceName() {
+    return spaceName;
+  }
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/ConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/ConfigStore.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+public interface ConfigStore<T extends ServiceConfiguration> {
+
+  T get(String id);
+
+  void bind(T conf);
+
+  void unbind(T conf);
+
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/ServiceConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/ServiceConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+public interface ServiceConfiguration {
+
+  String getId();
+
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/SpaceDependentConfigStore.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/SpaceDependentConfigStore.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+import org.apache.sling.api.resource.Resource;
+
+public interface SpaceDependentConfigStore<T extends SpaceDependentConfiguration>
+    extends ConfigStore<T> {
+
+  T get(Resource resource);
+
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/SpaceDependentConfiguration.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/config/SpaceDependentConfiguration.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.services.config;
+
+public interface SpaceDependentConfiguration extends ServiceConfiguration {
+
+  String getSpaceName();
+
+  @Override
+  default String getId() {
+    return getSpaceName();
+  }
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigStoreImpl.java
@@ -16,46 +16,31 @@
 
 package pl.ds.kyanite.common.components.services.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import pl.ds.kyanite.common.components.services.ContactFormConfigStore;
 import pl.ds.kyanite.common.components.services.ContactFormConfiguration;
+import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigStore;
+
 
 @Component(service = ContactFormConfigStore.class, immediate = true)
-public class ContactFormConfigStoreImpl implements ContactFormConfigStore {
-
-  private List<ContactFormConfiguration> configList = new ArrayList<>();
+public class ContactFormConfigStoreImpl
+    extends     BaseSpaceDependentConfigStore<ContactFormConfiguration>
+    implements  ContactFormConfigStore {
 
   @Reference(
       service = ContactFormConfiguration.class,
       cardinality = ReferenceCardinality.MULTIPLE,
       policy = ReferencePolicy.DYNAMIC,
-      bind = "bind",
-      unbind = "unbind"
-  )
+      bind = "bind", unbind = "unbind")
   public synchronized void bind(final ContactFormConfiguration config) {
-    if (configList == null) {
-      configList = new ArrayList<>();
-    }
-    configList.add(config);
-  }
-
-  public synchronized void unbind(final ContactFormConfiguration config) {
-    configList.remove(config);
+    super.bind(config);
   }
 
   @Override
-  public ContactFormConfiguration get(String spaceName) {
-    for (ContactFormConfiguration config : configList) {
-      if (spaceName.equals(config.getSpaceName())) {
-        return config;
-      }
-    }
-    return null;
+  public synchronized void unbind(final ContactFormConfiguration config) {
+    super.unbind(config);
   }
-
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigStoreImpl.java
@@ -27,8 +27,8 @@ import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigS
 
 @Component(service = ContactFormConfigStore.class, immediate = true)
 public class ContactFormConfigStoreImpl
-    extends     BaseSpaceDependentConfigStore<ContactFormConfiguration>
-    implements  ContactFormConfigStore {
+    extends BaseSpaceDependentConfigStore<ContactFormConfiguration>
+    implements ContactFormConfigStore {
 
   @Reference(
       service = ContactFormConfiguration.class,

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigurationImpl.java
@@ -25,9 +25,10 @@ import org.osgi.service.metatype.annotations.Designate;
 import pl.ds.kyanite.common.components.configurations.ContactFormConfigurationOcd;
 import pl.ds.kyanite.common.components.services.ContactFormConfiguration;
 
+
 @Component(service = ContactFormConfiguration.class)
 @Designate(ocd = ContactFormConfigurationOcd.class, factory = true)
-public class ContactFormConfigurationImpl implements ContactFormConfiguration {
+public class ContactFormConfigurationImpl implements  ContactFormConfiguration {
 
   private ContactFormConfigurationOcd config;
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/ContactFormConfigurationImpl.java
@@ -28,7 +28,7 @@ import pl.ds.kyanite.common.components.services.ContactFormConfiguration;
 
 @Component(service = ContactFormConfiguration.class)
 @Designate(ocd = ContactFormConfigurationOcd.class, factory = true)
-public class ContactFormConfigurationImpl implements  ContactFormConfiguration {
+public class ContactFormConfigurationImpl implements ContactFormConfiguration {
 
   private ContactFormConfigurationOcd config;
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigStoreImpl.java
@@ -16,43 +16,30 @@
 
 package pl.ds.kyanite.common.components.services.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import pl.ds.kyanite.common.components.services.CookieModalConfigStore;
 import pl.ds.kyanite.common.components.services.CookieModalConfiguration;
-
+import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigStore;
 
 @Component(service = CookieModalConfigStore.class, immediate = true)
-public class CookieModalConfigStoreImpl implements CookieModalConfigStore {
+public class CookieModalConfigStoreImpl
+    extends     BaseSpaceDependentConfigStore<CookieModalConfiguration>
+    implements  CookieModalConfigStore {
 
-  private List<CookieModalConfiguration> configsList = new ArrayList<>();
-
-  @Reference(service = CookieModalConfiguration.class,
-      cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC,
+  @Reference(
+      service = CookieModalConfiguration.class,
+      cardinality = ReferenceCardinality.MULTIPLE,
+      policy = ReferencePolicy.DYNAMIC,
       bind = "bind", unbind = "unbind")
   public synchronized void bind(final CookieModalConfiguration config) {
-    if (configsList == null) {
-      configsList = new ArrayList<>();
-    }
-    configsList.add(config);
+    super.bind(config);
   }
-
-  public synchronized void unbind(final CookieModalConfiguration config) {
-    configsList.remove(config);
-  }
-
 
   @Override
-  public CookieModalConfiguration get(String spaceName) {
-    for (CookieModalConfiguration confFact : configsList) {
-      if (spaceName.equals(confFact.getSpaceName())) {
-        return confFact;
-      }
-    }
-    return null;
+  public synchronized void unbind(final CookieModalConfiguration config) {
+    super.unbind(config);
   }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigStoreImpl.java
@@ -26,8 +26,8 @@ import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigS
 
 @Component(service = CookieModalConfigStore.class, immediate = true)
 public class CookieModalConfigStoreImpl
-    extends     BaseSpaceDependentConfigStore<CookieModalConfiguration>
-    implements  CookieModalConfigStore {
+    extends BaseSpaceDependentConfigStore<CookieModalConfiguration>
+    implements CookieModalConfigStore {
 
   @Reference(
       service = CookieModalConfiguration.class,

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigurationImpl.java
@@ -27,8 +27,8 @@ import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigu
 @Component(service = CookieModalConfiguration.class)
 @Designate(ocd = CookieModalConfigurationOcd.class, factory = true)
 public class CookieModalConfigurationImpl
-    extends     BaseSpaceDependentConfiguration
-    implements  CookieModalConfiguration {
+    extends BaseSpaceDependentConfiguration
+    implements CookieModalConfiguration {
 
   private String privacyPolicyPath;
   private String contactUsPath;

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/CookieModalConfigurationImpl.java
@@ -22,12 +22,14 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.metatype.annotations.Designate;
 import pl.ds.kyanite.common.components.configurations.CookieModalConfigurationOcd;
 import pl.ds.kyanite.common.components.services.CookieModalConfiguration;
+import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfiguration;
 
 @Component(service = CookieModalConfiguration.class)
 @Designate(ocd = CookieModalConfigurationOcd.class, factory = true)
-public class CookieModalConfigurationImpl implements CookieModalConfiguration {
+public class CookieModalConfigurationImpl
+    extends     BaseSpaceDependentConfiguration
+    implements  CookieModalConfiguration {
 
-  private String spaceName;
   private String privacyPolicyPath;
   private String contactUsPath;
 
@@ -37,11 +39,6 @@ public class CookieModalConfigurationImpl implements CookieModalConfiguration {
     this.spaceName = config.spaceName();
     this.privacyPolicyPath = config.privacyPolicyPath();
     this.contactUsPath = config.contactUsPath();
-  }
-
-  @Override
-  public String getSpaceName() {
-    return spaceName;
   }
 
   @Override

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/GoogleAnalyticsConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/GoogleAnalyticsConfigStoreImpl.java
@@ -16,19 +16,18 @@
 
 package pl.ds.kyanite.common.components.services.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import pl.ds.kyanite.common.components.services.GoogleAnalyticsConfigStore;
 import pl.ds.kyanite.common.components.services.GoogleAnalyticsConfiguration;
+import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigStore;
 
 @Component(service = GoogleAnalyticsConfigStore.class, immediate = true)
-public class GoogleAnalyticsConfigStoreImpl implements GoogleAnalyticsConfigStore {
-
-  private List<GoogleAnalyticsConfiguration> configList = new ArrayList<>();
+public class GoogleAnalyticsConfigStoreImpl
+    extends     BaseSpaceDependentConfigStore<GoogleAnalyticsConfiguration>
+    implements  GoogleAnalyticsConfigStore {
 
   @Reference(
       service = GoogleAnalyticsConfiguration.class,
@@ -38,24 +37,11 @@ public class GoogleAnalyticsConfigStoreImpl implements GoogleAnalyticsConfigStor
       unbind = "unbind"
   )
   public synchronized void bind(final GoogleAnalyticsConfiguration config) {
-    if (configList == null) {
-      configList = new ArrayList<>();
-    }
-    configList.add(config);
-  }
-
-  public synchronized void unbind(final GoogleAnalyticsConfiguration config) {
-    configList.remove(config);
+    super.bind(config);
   }
 
   @Override
-  public GoogleAnalyticsConfiguration get(String spaceName) {
-    for (GoogleAnalyticsConfiguration config : configList) {
-      if (spaceName.equals(config.getSpaceName())) {
-        return config;
-      }
-    }
-    return null;
+  public synchronized void unbind(final GoogleAnalyticsConfiguration config) {
+    super.unbind(config);
   }
-
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/GoogleAnalyticsConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/GoogleAnalyticsConfigStoreImpl.java
@@ -26,8 +26,8 @@ import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigS
 
 @Component(service = GoogleAnalyticsConfigStore.class, immediate = true)
 public class GoogleAnalyticsConfigStoreImpl
-    extends     BaseSpaceDependentConfigStore<GoogleAnalyticsConfiguration>
-    implements  GoogleAnalyticsConfigStore {
+    extends BaseSpaceDependentConfigStore<GoogleAnalyticsConfiguration>
+    implements GoogleAnalyticsConfigStore {
 
   @Reference(
       service = GoogleAnalyticsConfiguration.class,

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/GoogleAnalyticsConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/GoogleAnalyticsConfigurationImpl.java
@@ -27,8 +27,7 @@ import pl.ds.kyanite.common.components.services.GoogleAnalyticsConfiguration;
 
 @Component(service = GoogleAnalyticsConfiguration.class)
 @Designate(ocd = GoogleAnalyticsConfigurationOcd.class, factory = true)
-public class GoogleAnalyticsConfigurationImpl implements
-    GoogleAnalyticsConfiguration {
+public class GoogleAnalyticsConfigurationImpl implements GoogleAnalyticsConfiguration {
 
   private GoogleAnalyticsConfigurationOcd config;
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/LibraryIconConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/LibraryIconConfigStoreImpl.java
@@ -29,8 +29,8 @@ import pl.ds.kyanite.common.components.services.config.BaseConfigStore;
 
 @Component(service = LibraryIconConfigStore.class, immediate = true)
 public class LibraryIconConfigStoreImpl
-    extends     BaseConfigStore<LibraryIconConfig>
-    implements  LibraryIconConfigStore {
+    extends BaseConfigStore<LibraryIconConfig>
+    implements LibraryIconConfigStore {
 
   @Override
   @Reference(

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/LibraryIconConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/LibraryIconConfigStoreImpl.java
@@ -24,25 +24,28 @@ import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import pl.ds.kyanite.common.components.services.LibraryIconConfig;
 import pl.ds.kyanite.common.components.services.LibraryIconConfigStore;
+import pl.ds.kyanite.common.components.services.config.BaseConfigStore;
 
 
 @Component(service = LibraryIconConfigStore.class, immediate = true)
-public class LibraryIconConfigStoreImpl implements LibraryIconConfigStore {
+public class LibraryIconConfigStoreImpl
+    extends     BaseConfigStore<LibraryIconConfig>
+    implements  LibraryIconConfigStore {
 
-  private List<LibraryIconConfig> configsList;
-
-  @Reference(service = LibraryIconConfig.class,
-      cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC,
-      bind = "bind", unbind = "unbind")
+  @Override
+  @Reference(
+      service = LibraryIconConfig.class,
+      cardinality = ReferenceCardinality.MULTIPLE,
+      policy = ReferencePolicy.DYNAMIC,
+      bind = "bind", unbind = "unbind"
+  )
   public synchronized void bind(final LibraryIconConfig config) {
-    if (configsList == null) {
-      configsList = new ArrayList<>();
-    }
-    configsList.add(config);
+    super.bind(config);
   }
 
+  @Override
   public synchronized void unbind(final LibraryIconConfig config) {
-    configsList.remove(config);
+    super.unbind(config);
   }
 
   @Override
@@ -53,13 +56,4 @@ public class LibraryIconConfigStoreImpl implements LibraryIconConfigStore {
     return configsList;
   }
 
-  @Override
-  public LibraryIconConfig get(String id) {
-    for (LibraryIconConfig confFact : configsList) {
-      if (id.equals(confFact.getId())) {
-        return confFact;
-      }
-    }
-    return null;
-  }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigStoreImpl.java
@@ -16,43 +16,32 @@
 
 package pl.ds.kyanite.common.components.services.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import pl.ds.kyanite.common.components.services.RecaptchaConfigStore;
 import pl.ds.kyanite.common.components.services.RecaptchaConfiguration;
+import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigStore;
 
 
 @Component(service = RecaptchaConfigStore.class, immediate = true)
-public class RecaptchaConfigStoreImpl implements RecaptchaConfigStore {
-
-  private List<RecaptchaConfiguration> configsList = new ArrayList<>();
-
-  @Reference(service = RecaptchaConfiguration.class,
-      cardinality = ReferenceCardinality.MULTIPLE, policy = ReferencePolicy.DYNAMIC,
-      bind = "bind", unbind = "unbind")
-  public synchronized void bind(final RecaptchaConfiguration config) {
-    if (configsList == null) {
-      configsList = new ArrayList<>();
-    }
-    configsList.add(config);
-  }
-
-  public synchronized void unbind(final RecaptchaConfiguration config) {
-    configsList.remove(config);
-  }
-
+public class RecaptchaConfigStoreImpl
+    extends     BaseSpaceDependentConfigStore<RecaptchaConfiguration>
+    implements  RecaptchaConfigStore {
 
   @Override
-  public RecaptchaConfiguration get(String spaceName) {
-    for (RecaptchaConfiguration confFact : configsList) {
-      if (spaceName.equals(confFact.getSpaceName())) {
-        return confFact;
-      }
-    }
-    return null;
+  @Reference(
+      service = RecaptchaConfiguration.class,
+      cardinality = ReferenceCardinality.MULTIPLE,
+      policy = ReferencePolicy.DYNAMIC,
+      bind = "bind", unbind = "unbind")
+  public synchronized void bind(final RecaptchaConfiguration config) {
+    super.bind(config);
+  }
+
+  @Override
+  public synchronized void unbind(final RecaptchaConfiguration config) {
+    super.unbind(config);
   }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigStoreImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigStoreImpl.java
@@ -27,8 +27,8 @@ import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigS
 
 @Component(service = RecaptchaConfigStore.class, immediate = true)
 public class RecaptchaConfigStoreImpl
-    extends     BaseSpaceDependentConfigStore<RecaptchaConfiguration>
-    implements  RecaptchaConfigStore {
+    extends BaseSpaceDependentConfigStore<RecaptchaConfiguration>
+    implements RecaptchaConfigStore {
 
   @Override
   @Reference(

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigurationImpl.java
@@ -27,8 +27,8 @@ import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfigu
 @Component(service = RecaptchaConfiguration.class)
 @Designate(ocd = RecaptchaConfigurationOcd.class, factory = true)
 public class RecaptchaConfigurationImpl
-    extends     BaseSpaceDependentConfiguration
-    implements  RecaptchaConfiguration {
+    extends BaseSpaceDependentConfiguration
+    implements RecaptchaConfiguration {
 
   private String captchaPublicKey;
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigurationImpl.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/services/impl/RecaptchaConfigurationImpl.java
@@ -22,12 +22,14 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.metatype.annotations.Designate;
 import pl.ds.kyanite.common.components.configurations.RecaptchaConfigurationOcd;
 import pl.ds.kyanite.common.components.services.RecaptchaConfiguration;
+import pl.ds.kyanite.common.components.services.config.BaseSpaceDependentConfiguration;
 
 @Component(service = RecaptchaConfiguration.class)
 @Designate(ocd = RecaptchaConfigurationOcd.class, factory = true)
-public class RecaptchaConfigurationImpl implements RecaptchaConfiguration {
+public class RecaptchaConfigurationImpl
+    extends     BaseSpaceDependentConfiguration
+    implements  RecaptchaConfiguration {
 
-  private String spaceName;
   private String captchaPublicKey;
 
   @Activate
@@ -35,11 +37,6 @@ public class RecaptchaConfigurationImpl implements RecaptchaConfiguration {
   protected void activate(final RecaptchaConfigurationOcd config) {
     this.spaceName = config.spaceName();
     this.captchaPublicKey = config.captchaPublicKey();
-  }
-
-  @Override
-  public String getSpaceName() {
-    return spaceName;
   }
 
   @Override


### PR DESCRIPTION
Functionality of retrieving configurations by id or space name was extracted into some interfaces and abstract classes, to decrease amount of boilerplate code and keep sling-specific technical code from business logic.

- in ConfigStore class it's enough to just redirect 'bind' and 'unbind' methods to parent, BaseConfigStore class. 
- in space-dependent configuration in 'activate' method you must assign value to spaceName 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
