### PR TITLE
KYAN-183 fix Navbar group to allow manual adding to a page

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/.content.json
@@ -6,7 +6,7 @@
     "/apps/kyanite/common/components/navbar/navbarmenu",
     "/libs/kyanite/common/components/navbar/navbarmenu"
   ],
-  "group": "Components",
+  "group": "Kyanite Layouts",
   "sling:resourceType": "ws:Component",
   "title": "Navbar"
 }


### PR DESCRIPTION
Navbar moved from 'Components' group to 'Kyanite layouts'. It is now displayed in 'Components' tab and author can add it to a page.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
