### PR TITLE
KYAN-233 make Navbar Mega Dropdown available in Navbar Start

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarbrand/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarbrand/.content.json
@@ -4,8 +4,7 @@
     "/apps/kyanite/common/components/navbar/navbaritem",
     "/libs/kyanite/common/components/navbar/navbaritem",
     "/apps/kyanite/common/components/navbar/navbardropdown",
-    "/libs/kyanite/common/components/navbar/navbardropdown",
-    "/libs/kyanite/common/components/navbar/navbarmegadropdown"
+    "/libs/kyanite/common/components/navbar/navbardropdown"
   ],
   "group": "Kyanite sub-components",
   "sling:resourceType": "ws:Component",

--- a/applications/common/frontend/src/components/Navbar/navbar.ts
+++ b/applications/common/frontend/src/components/Navbar/navbar.ts
@@ -16,6 +16,8 @@
 
 import { breakpoints } from 'src/helpers/breakpoints';
 
+const navbarMenuElementsSelector = ':is(.navbar-start, .navbar-end)';
+
 document.addEventListener('scroll', () => {
   const navbar = document.querySelector('.navbar');
   const isTransparent = navbar.classList.contains('is-transparent');
@@ -56,8 +58,8 @@ document.addEventListener(window.KYANITE_ON_DOM_CONTENT_LOAD, () => {
   });
 
   // Get all dropdowns items
-  const $navbarMega = Array.prototype.slice.call(
-    document.querySelectorAll('.navbar-end .navbar-item.has-dropdown')
+  const $navbarMenuDropdowns = Array.prototype.slice.call(
+    document.querySelectorAll(`${navbarMenuElementsSelector} .navbar-item.has-dropdown`)
   );
   const desktopMQ = window.matchMedia(`(min-width: ${breakpoints.lg}px)`);
 
@@ -70,7 +72,7 @@ document.addEventListener(window.KYANITE_ON_DOM_CONTENT_LOAD, () => {
 
     // On desktop the dropdowns are hoverable
     if (desktopMQ.matches) {
-      $navbarMega.forEach((el) => {
+      $navbarMenuDropdowns.forEach((el) => {
         el.classList.add('is-hoverable');
         el.classList.remove('is-active');
         el.removeEventListener('click', onClick);
@@ -80,7 +82,7 @@ document.addEventListener(window.KYANITE_ON_DOM_CONTENT_LOAD, () => {
     }
 
     // On mobile the dropdowns are clickable
-    $navbarMega.forEach((el) => {
+    $navbarMenuDropdowns.forEach((el) => {
       el.classList.remove('is-hoverable');
       el.classList.remove('is-active');
       el.addEventListener('click', onClick);
@@ -124,7 +126,7 @@ function handleFixedNavbarPosition() {
 function handleMegamenuHover(isDesktop) {
   const menu = document.querySelector('.navbar-menu');
   const allNavbarItems = Array.from(
-    document.querySelectorAll('.navbar-end > .navbar-item')
+    document.querySelectorAll(`${navbarMenuElementsSelector} > .navbar-item`)
   ); // only first level
 
   if (!allNavbarItems.length) {


### PR DESCRIPTION
In Bulma navbar-mega-dropdown is supposed to go under navbar-start and navbar-end. Historically Kyanite mega was designed for navbar-end and forgotten to be allowed under navbar-start.

Also possibility to add it to Navbar brand was removed as it doesn't correspond to Bulma usecase and we don't have styles for that at the moment.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
