### PR TITLE
WSIO-716 Image preview carousel on blog related pages

### DIFF
--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
@@ -109,6 +109,7 @@
             },
             "column4": {
               "sling:resourceType": "kyanite/common/components/columns/column",
+              "customClass" : "blogArticleContent",
               "desktopColumnStyle": {
                 "jcr:primaryType": "nt:unstructured",
                 "size": "eight",

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
@@ -109,7 +109,7 @@
             },
             "column4": {
               "sling:resourceType": "kyanite/common/components/columns/column",
-              "customClass" : "blogArticleContent",
+              "customClass" : "previewImageContainer",
               "desktopColumnStyle": {
                 "jcr:primaryType": "nt:unstructured",
                 "size": "eight",

--- a/applications/common/frontend/src/components/Image/Image.scss
+++ b/applications/common/frontend/src/components/Image/Image.scss
@@ -48,7 +48,7 @@ $color-shadow-end: rgba(#605e78, 0.07);
   padding-right: 15px;
 }
 
-.blogArticleContent {
+.previewImageContainer {
 
   .image {
     position: relative;

--- a/applications/common/frontend/src/components/Image/Image.scss
+++ b/applications/common/frontend/src/components/Image/Image.scss
@@ -47,3 +47,22 @@ $color-shadow-end: rgba(#605e78, 0.07);
 .viewer-open > .navbar {
   padding-right: 15px;
 }
+
+.blogArticleContent {
+
+  .image {
+    position: relative;
+  }
+
+  .previewCarouselImage {
+    cursor: pointer;
+  }
+
+  .previewIcon {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: auto;
+    pointer-events: none;
+  }
+}

--- a/applications/common/frontend/src/components/Image/image.ts
+++ b/applications/common/frontend/src/components/Image/image.ts
@@ -60,8 +60,8 @@ const createPreviewCarousel = (imageContainer) => {
 }
 
 if (imageCarouselTemplates.some(className => document.body.classList.contains(className))) {
-  const imageContainer = document.querySelector<HTMLElement>(".blogArticleContent");
-  const previewCarouselImages = document.querySelectorAll<HTMLElement>(".blogArticleContent .image");
+  const imageContainer = document.querySelector<HTMLElement>(".previewImageContainer");
+  const previewCarouselImages = document.querySelectorAll<HTMLElement>(".previewImageContainer .image");
 
   previewCarouselImages.forEach(imageContainer => {
     const imageElement = imageContainer.querySelector("img");

--- a/applications/common/frontend/src/components/Image/image.ts
+++ b/applications/common/frontend/src/components/Image/image.ts
@@ -27,7 +27,13 @@ const createSeparatePreviews = (imageList) => {
       zoomable: false,
       movable: false,
       title: false,
-      url: 'data-lightbox-asset'
+      url: 'data-lightbox-asset',
+      show() {
+        document.querySelector("html").style.overflowY = "hidden";
+      },
+      hidden() {
+        document.querySelector("html").style.overflowY = "scroll";
+      }
     });
   });
 };

--- a/applications/common/frontend/src/components/Image/image.ts
+++ b/applications/common/frontend/src/components/Image/image.ts
@@ -16,16 +16,59 @@
 
 import Viewer from "viewerjs";
 
-const imagesWithLightbox = document.querySelectorAll<HTMLImageElement>(
-  ".image--lightbox"
-);
-imagesWithLightbox.forEach((image) => {
-  new Viewer(image, {
+// We may extend this array later with additional pages that need to have an image preview carousel
+const imageCarouselTemplates = ["template-blogarticlepage"];
+
+const createSeparatePreviews = (imageList) => {
+  imageList.forEach((image) => {
+    new Viewer(image, {
+      navbar: false,
+      toolbar: false,
+      zoomable: false,
+      movable: false,
+      title: false,
+      url: 'data-lightbox-asset'
+    });
+  });
+};
+
+const createPreviewCarousel = (imageContainer) => {
+  new Viewer(imageContainer, {
     navbar: false,
-    toolbar: false,
     zoomable: false,
     movable: false,
     title: false,
-    url: 'data-lightbox-asset'
+    scalable: false,
+    url: 'data-lightbox-asset',
+    toolbar: {
+      prev: 1,
+      next: 1,
+    },
+    show() {
+      document.querySelector("html").style.overflowY = "hidden";
+    },
+    hidden() {
+      document.querySelector("html").style.overflowY = "scroll";
+    }
   });
-});
+}
+
+if (imageCarouselTemplates.some(className => document.body.classList.contains(className))) {
+  const imageContainer = document.querySelector<HTMLElement>(".blogArticleContent");
+  const previewCarouselImages = document.querySelectorAll<HTMLElement>(".blogArticleContent .image");
+
+  previewCarouselImages.forEach(imageContainer => {
+    const imageElement = imageContainer.querySelector("img");
+    imageElement.classList.add("previewCarouselImage");
+    imageContainer.innerHTML += '<svg class="previewIcon" width="30" height="30" viewBox="9 9 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
+        '  <rect width="45" height="45" rx="24" x="9" y="9" fill="#1B1C20"/>\n' +
+        '  <path fill-rule="evenodd" clip-rule="evenodd" d="M32 24H40V32H42V22H32V24ZM24 32H22V42H32V40H24V32Z" fill="#ECF5FF"/>\n' +
+        '</svg>';
+  });
+  createPreviewCarousel(imageContainer);
+} else {
+  const imagesWithLightbox = document.querySelectorAll<HTMLImageElement>(
+      ".image--lightbox"
+  );
+  createSeparatePreviews(imagesWithLightbox);
+}

--- a/distribution/src/main/groovy/0.5.1/custom_classes_to_blog_columns.groovy
+++ b/distribution/src/main/groovy/0.5.1/custom_classes_to_blog_columns.groovy
@@ -24,7 +24,7 @@
 dryRun = true
 rootPaths = ['/content']
 newPropertyName = 'customClass'
-newPropertyValue = 'blogArticleContent'
+newPropertyValue = 'previewImageContainer'
 contentColumnPath = 'pagecontainer/section/container/columns1/column4'
 updatedPagesCount = 0
 

--- a/distribution/src/main/groovy/0.5.1/custom_classes_to_blog_columns.groovy
+++ b/distribution/src/main/groovy/0.5.1/custom_classes_to_blog_columns.groovy
@@ -1,3 +1,26 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This script changes the content structure of the button components
+ * what has two bunch for icons properties (right and left)
+ * For every bunch properties will be created as separate nodes
+ * and old properties will be removed.
+ */
+
 dryRun = true
 rootPaths = ['/content']
 newPropertyName = 'customClass'

--- a/distribution/src/main/groovy/0.5.1/custom_classes_to_blog_columns.groovy
+++ b/distribution/src/main/groovy/0.5.1/custom_classes_to_blog_columns.groovy
@@ -1,0 +1,38 @@
+dryRun = true
+rootPaths = ['/content']
+newPropertyName = 'customClass'
+newPropertyValue = 'blogArticleContent'
+contentColumnPath = 'pagecontainer/section/container/columns1/column4'
+updatedPagesCount = 0
+
+def findBlogArticlePageInstances(String rootPath) {
+    return resourceResolver.findResources("SELECT * FROM [nt:base] AS s WHERE ISDESCENDANTNODE([$rootPath]) " +
+            "AND ([sling:resourceType]='kyanite/blogs/components/blogarticlepage' " +
+            "OR [sling:resourceType]='streamx-dev/components/blogarticlepage')", "JCR-SQL2")
+}
+
+def addNewProperty(Resource resource) {
+    def contentColumnResource = resource.getChild(contentColumnPath)
+    def resourceMVM = contentColumnResource.adaptTo(org.apache.sling.api.resource.ModifiableValueMap)
+    resourceMVM.put(newPropertyName, newPropertyValue)
+}
+
+rootPaths.each {
+    rootPath ->
+        findBlogArticlePageInstances(rootPath).each {
+            res ->
+                try {
+                    addNewProperty(res)
+                    updatedPagesCount++
+                } catch (Exception e) {
+                    println("Error processing resource: " + res.path + " with error: " + e.getMessage())
+                }
+        }
+}
+
+if (dryRun) {
+    println("Script in dryRun mode. Updated $updatedPagesCount 'BlogArticlePage' instance(s).")
+} else {
+    println("Updated $updatedPagesCount 'BlogArticlePage' instance(s).")
+    resourceResolver.commit()
+}


### PR DESCRIPTION
Adding image preview carousel to pages based on `blogArticlePage` template. It will pick up all images in the blog body and create a lightbox image viewer where users of the page will be able to browse all the images.

## Description
These changes also require the execution of a Groovy script to provide the necessary custom CSS class to the already existing `blogArticlePage` instances.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
