### PR TITLE
introduce a contract for extending/overriding layout templates

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/MultiTemplateComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/MultiTemplateComponent.java
@@ -21,28 +21,44 @@ package pl.ds.kyanite.common.components.models.layouts;
  * It would be nice to have in any component if there is a chance for its layout to be customized -
  * consider it a contract.
  *
+ * <p>
  * Use cases:
- *  - you are using/extending an existing component and you want to change its layout/add a new one
- *  - you are developing a component that can have different layouts by design
- *    (e.g. horizontal and vertical tabs)
+ * <ul>
+ *    <li>you are using/extending an existing component and you want to change its layout
+ *    or add a new one</li>
+ *    <li>you are developing a component that can have different layouts by design
+ *    (e.g. horizontal and vertical tabs)</li>
+ * </ul>
+ * </p>
  *
- * Component must follow this rules:
- *  1)  component has a default template under template/template-default.html
- *  2)  component's model implements MultiTemplateComponent interface
- *  3)  [component].html imports template by relative path which is retrieved via interface method:
- *      <code>
- *        <sly data-sly-use.template="${model.templatePath}"
- *             data-sly-call="${template.template @ model=model}"></sly>
- *      </code>
+ * <p>Component must follow this rules:
+ * <ol>
+ *    <li>component has a default template under templates/template-default.html</li>
+ *    <li>component's model implements MultiTemplateComponent interface</li>
+ *    <li>[component].html imports template by relative path retrieved via interface method
+ *      <p>&lt;sly data-sly-use.template=&quot;${model.templatePath}&quot;</p>
+ *      <p>       data-sly-call=&quot;${template.template @ model=model}&quot;&gt;&lt;/sly&gt;</p>
+ *    </li>
+ * </ol>
+ * </p>
  *
- * Then, you may want to customize component's layout in your project:
- * 1) override default layout:
- *    - just create your own ./templates/template-default.html for that component
- * 2) add one or more variants of component's layout:
- *    - add additional templates under ./templates
- *    - include /libs/kyanite/common/components/common/template field into component's dialog
- *    - add options representing your templates to included select
- *    - don't forget to initialize your component with default template
+ * <p>Then, you may want to customize component's layout in your project:
+ * <ol>
+ *    <li>override default layout:
+ *      <ul>
+ *        <li>just create your own ./templates/template-default.html for that component</li>
+ *      </ul>
+ *    </li>
+ *    <li>add one or more variants of component's layout:
+ *      <ul>
+ *        <li>add additional templates under ./templates</li>
+ *        <li>include /libs/kyanite/common/components/common/template into component's dialog</li>
+ *        <li>add options representing your templates to included select</li>
+ *        <li>initialize the templatePath property, because now you actually store it in JCR</li>
+ *      </ul>
+ *    </li>
+ * </ol>
+ * </p>
  */
 public interface MultiTemplateComponent {
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/MultiTemplateComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/MultiTemplateComponent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.models.layouts;
+
+/**
+ * This interface provides a common way of adding/overriding layouts for components.
+ * It would be nice to have in any component if there is a chance for its layout to be customized -
+ * consider it a contract.
+ *
+ * Use cases:
+ *  - you are using/extending an existing component and you want to change its layout/add a new one
+ *  - you are developing a component that can have different layouts by design
+ *    (e.g. horizontal and vertical tabs)
+ *
+ * Component must follow this rules:
+ *  1)  component has a default template under template/template-default.html
+ *  2)  component's model implements MultiTemplateComponent interface
+ *  3)  [component].html imports template by relative path which is retrieved via interface method:
+ *      <code>
+ *        <sly data-sly-use.template="${model.templatePath}"
+ *             data-sly-call="${template.template @ model=model}"></sly>
+ *      </code>
+ *
+ * Then, you may want to customize component's layout in your project:
+ * 1) override default layout:
+ *    - just create your own ./templates/template-default.html for that component
+ * 2) add one or more variants of component's layout:
+ *    - add additional templates under ./templates
+ *    - include /libs/kyanite/common/components/common/template field into component's dialog
+ *    - add options representing your templates to included select
+ *    - don't forget to initialize your component with default template
+ */
+public interface MultiTemplateComponent {
+
+  /**
+   * Return layout template relative path. Returns default template path by default,
+   * so there is no need to override the method and add a property to you component
+   * if you will only have one layout - just place the layout in the template-default.html file
+   *
+   * @return layout template's relative path
+   */
+  default String getTemplatePath() {
+    return "./templates/template-default.html";
+  }
+
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/TemplateHandler.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/TemplateHandler.java
@@ -33,28 +33,32 @@ package pl.ds.kyanite.common.components.models.layouts;
  *
  * <p>Component must follow this rules:
  * <ol>
- *    <li>component has a default template under templates/template-default.html</li>
- *    <li>component's model implements MultiTemplateComponent interface</li>
- *    <li>[component].html imports template by relative path retrieved via interface method
+ *    <li>component has a default template under templates/template-default.html declared as
+ *      &lt;template data-sly-template.template="${ @ model}"&gt;</li>
+ *    <li>component's model implements TemplateHandler interface</li>
+ *    <li>[component].html imports template using the path returned by getTemplatePath() method:
  *      <p>&lt;sly data-sly-use.template=&quot;${model.templatePath}&quot;</p>
  *      <p>       data-sly-call=&quot;${template.template @ model=model}&quot;&gt;&lt;/sly&gt;</p>
  *    </li>
  * </ol>
  * </p>
  *
- * <p>Then, you may want to customize component's layout in your project:
+ * <p>In your project, whether you are creating your own component based on an existing one
+ *  or simply overwriting part of it, you may want to customize the component's layout:
  * <ol>
  *    <li>override default layout:
  *      <ul>
- *        <li>just create your own ./templates/template-default.html for that component</li>
+ *        <li>just create your own template-default.html for the component under component's
+ *    /templates folder (for overwriting it will be /apps/path/to/base/component/templates)</li>
  *      </ul>
  *    </li>
  *    <li>add one or more variants of component's layout:
  *      <ul>
- *        <li>add additional templates under ./templates</li>
+ *        <li>add additional templates under component /templates folder</li>
  *        <li>include /libs/kyanite/common/components/common/template into component's dialog</li>
  *        <li>add options representing your templates to included select</li>
- *        <li>initialize the templatePath property, because now you actually store it in JCR</li>
+ *        <li>initialize the templatePath property in /template/.content.json,
+ *            because now you actually store it in JCR</li>
  *      </ul>
  *    </li>
  * </ol>

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/TemplateHandler.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/TemplateHandler.java
@@ -60,7 +60,7 @@ package pl.ds.kyanite.common.components.models.layouts;
  * </ol>
  * </p>
  */
-public interface MultiTemplateComponent {
+public interface TemplateHandler {
 
   /**
    * Return layout template relative path. Returns default template path by default,

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/package-info.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Dynamic Solutions
+ * Copyright (C) 2024 Dynamic Solutions
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/package-info.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/layouts/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2023 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Version("1.0.0")
+package pl.ds.kyanite.common.components.models.layouts;
+
+import org.osgi.annotation.versioning.Version;

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/common/template/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/common/template/.content.json
@@ -1,0 +1,11 @@
+{
+  "sling:resourceType": "wcm/dialogs/components/select",
+  "name": "templatePath",
+  "label": "Layout",
+  "default": {
+    "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+    "label": "Default",
+    "value": "./templates/template-default.html",
+    "selected": true
+  }
+}


### PR DESCRIPTION
I propose a contract for components that:
- may have their layouts customized in other projects
- have multiple layouts by design (e.g. horizontal/vertical tabs)

## Description
Contract includes:
1. an interface to be implemented by component models
2. a dialog field to be included by components when layout choice is required
3. rules that component should follow:
- implement MultiTemplateComponent interface (no overriding required until we need a choice of layout)
- have default layout in ./templates/template-default.html file

More detailed explanation is in MultiTemplateComponent javadoc.

## Motivation and Context
It's always better to do the same things the same way, but up to this moment we haven't had a contract for component layouts naming and placement, as well as for the way we override/add layouts.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
