### PR TITLE
WSIO-732 Introduce mechanism to calculate colspans for table cells that don't have "Columns" explicitly set

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableCellComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableCellComponent.java
@@ -16,39 +16,135 @@
 
 package pl.ds.kyanite.common.components.models.table;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
-import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import pl.ds.kyanite.common.components.models.table.dto.TableCellData;
+import pl.ds.kyanite.common.components.models.table.dto.TableRowData;
 
+@Slf4j
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
 public class TableCellComponent {
 
   private static final String DEFAULT_TEXT = "Content";
+  private static final int DEFAULT_COLSPAN = 1;
+  private static final int DEFAULT_ROWSPAN = 1;
 
   @Inject
   @Getter
-  @Default(values = DEFAULT_TEXT)
   private String text;
 
   @Inject
-  @Getter
-  @Default(intValues = 1)
-  private int columns;
+  private Integer columns;
 
   @Inject
-  @Getter
-  @Default(intValues = 1)
-  private int rows;
+  private Integer rows;
+
+  @SlingObject
+  private Resource currentResource;
 
   @PostConstruct
   private void init() {
-    if (text.isEmpty()) {
+    if (StringUtils.isEmpty(text)) {
       text = DEFAULT_TEXT;
     }
+  }
+
+  public int getColspan() {
+    return columns != null ? columns : computeColspan();
+  }
+
+  public int getRowspan() {
+    return rows != null ? rows : DEFAULT_ROWSPAN;
+  }
+
+  private int computeColspan() {
+    Optional<TableComponent> parentTable = Optional
+            .ofNullable(currentResource.getParent()) // table row
+            .map(Resource::getParent) // table head or body
+            .map(Resource::getParent) // the table
+            .map(tableResource -> tableResource.adaptTo(TableComponent.class));
+
+    if (parentTable.isEmpty() || parentTable.get().isScrollable()) {
+      return DEFAULT_COLSPAN;
+    }
+
+    Resource parentRow = currentResource.getParent();
+
+    List<TableCellData> tableCells = StreamSupport
+            .stream(parentRow.getChildren().spliterator(), false)
+            .map(cell -> new TableCellData(
+                    cell.getValueMap().get("columns", Integer.class),
+                    cell.getPath().equals(currentResource.getPath())))
+            .toList();
+
+    TableRowData tableRowData = new TableRowData(tableCells);
+
+    return computeColspan(tableRowData);
+  }
+
+  /**
+   * Computes colspan for a cell that hasn't got the columns property specified.
+   * Attempts to give each such cell the same colspan, if possible.
+   * It takes into account colspans from other cells in the same row.
+   */
+  private static int computeColspan(TableRowData row) {
+    int summaryAvailableColspan = TableComponent.DEFAULT_SUMMARY_COLSPAN
+            - row.getSummaryColspanTakenByCellsWithColumnsSpecified();
+
+    if (summaryAvailableColspan < 1) {
+      return 1;
+    }
+
+    int colspanAvailableForSingleCell = summaryAvailableColspan
+            / row.getNumberOfCellsWithColumnsUnspecified();
+    if (colspanAvailableForSingleCell == 0) {
+      colspanAvailableForSingleCell = 1;
+    }
+
+    if (summaryAvailableColspan
+            % row.getNumberOfCellsWithColumnsUnspecified() == 0) {
+      // all cells are able to receive the same colspan
+      return colspanAvailableForSingleCell;
+    }
+
+    // ... otherwise - we have some additional colspan space to distribute between cells
+    int colspanLeftToDistribute = summaryAvailableColspan
+            - row.getNumberOfCellsWithColumnsUnspecified() * colspanAvailableForSingleCell;
+
+    int indexOfCurrentCellInCellsWithColumnsUnspecified =
+            getIndexOfCurrentCellInCellsWithColumnsUnspecified(row.getTableCellData());
+
+    if (indexOfCurrentCellInCellsWithColumnsUnspecified < colspanLeftToDistribute) {
+      // when giving additional +1 to colspan, prefer cells from the left
+      return colspanAvailableForSingleCell + 1;
+    } else {
+      return colspanAvailableForSingleCell;
+    }
+  }
+
+  private static int getIndexOfCurrentCellInCellsWithColumnsUnspecified(
+          List<TableCellData> tableCells) {
+    int resultIndex = 0;
+    for (TableCellData tableCell : tableCells) {
+      if (tableCell.isCurrentCell()) {
+        return resultIndex;
+      }
+      if (tableCell.columns() == null) {
+        resultIndex++;
+      }
+    }
+
+    throw new IllegalStateException("Expected to always find the current cell in cells list");
   }
 
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableComponent.java
@@ -28,6 +28,8 @@ import org.apache.sling.models.annotations.Model;
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
 public class TableComponent {
 
+  static final int DEFAULT_SUMMARY_COLSPAN = 12;
+
   @Inject
   private boolean isBordered;
 

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/dto/TableCellData.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/dto/TableCellData.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.models.table.dto;
+
+public record TableCellData(
+        Integer columns,
+        boolean isCurrentCell) {
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/dto/TableRowData.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/dto/TableRowData.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.models.table.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public final class TableRowData {
+  private final List<TableCellData> tableCellData;
+  private final int numberOfCellsWithColumnsUnspecified;
+  private final int summaryColspanTakenByCellsWithColumnsSpecified;
+
+  public TableRowData(List<TableCellData> tableCellData) {
+    this.tableCellData = List.copyOf(tableCellData);
+
+    numberOfCellsWithColumnsUnspecified = (int) tableCellData.stream()
+            .filter(cell -> cell.columns() == null)
+            .count();
+
+    summaryColspanTakenByCellsWithColumnsSpecified = tableCellData.stream()
+            .filter(cell -> cell.columns() != null)
+            .mapToInt(TableCellData::columns)
+            .sum();
+  }
+}

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/editConfig/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/editConfig/.content.json
@@ -1,0 +1,3 @@
+{
+  "reloadOnUpdate": "parent"
+}

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
@@ -17,7 +17,7 @@
 */-->
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.table.TableCellComponent">
-  <td rowspan="${model.rows}" colspan="${model.columns}">
+  <td rowspan="${model.rowspan}" colspan="${model.colspan}">
     ${model.text @ context='unsafe'}
   </td>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tableheadcell/editConfig/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tableheadcell/editConfig/.content.json
@@ -1,0 +1,3 @@
+{
+  "reloadOnUpdate": "parent"
+}

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tableheadcell/tableheadcell.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tableheadcell/tableheadcell.html
@@ -17,7 +17,7 @@
 */-->
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.table.TableHeadCellComponent">
-  <th rowspan="${model.rows}" colspan="${model.columns}">
+  <th rowspan="${model.rowspan}" colspan="${model.colspan}">
     ${model.text @ context='html'}
   </th>
 </sly>

--- a/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableCellComponentTest.java
+++ b/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableCellComponentTest.java
@@ -47,8 +47,8 @@ public class TableCellComponentTest {
         .adaptTo(TableCellComponent.class);
     assertThat(model).isNotNull();
     assertThat(model.getText()).isEqualTo("Content");
-    assertThat(model.getRows()).isEqualTo(1);
-    assertThat(model.getColumns()).isEqualTo(1);
+    assertThat(model.getRowspan()).isEqualTo(1);
+    assertThat(model.getColspan()).isEqualTo(12);
   }
 
   @Test
@@ -56,7 +56,7 @@ public class TableCellComponentTest {
     TableCellComponent model = context.resourceResolver().getResource(PATH + "/tablebody/tablerow2/complex")
         .adaptTo(TableCellComponent.class);
     assertThat(model.getText()).isEqualTo("Table cell text");
-    assertThat(model.getRows()).isEqualTo(2);
-    assertThat(model.getColumns()).isEqualTo(3);
+    assertThat(model.getRowspan()).isEqualTo(2);
+    assertThat(model.getColspan()).isEqualTo(3);
   }
 }

--- a/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableColspansCalculationTest.java
+++ b/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableColspansCalculationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2024 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.models.table;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.*;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.apache.sling.testing.mock.sling.junit5.SlingContext;
+import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(SlingContextExtension.class)
+public class TableColspansCalculationTest {
+
+  private final SlingContext context = new SlingContext(ResourceResolverType.RESOURCERESOLVER_MOCK);
+
+  @BeforeEach
+  public void init() {
+    context.addModelsForClasses(TableCellComponent.class, TableHeadCellComponent.class, TableComponent.class);
+  }
+
+  private static Stream<Arguments> inputColumnsAndExpectedComputedColspans() {
+    return Stream.of(
+            Arguments.of(
+                    columns(4, 4, 4, null),
+                    colspans(4, 4, 4, 1)),
+            Arguments.of(
+                    columns(4, null, 4, null),
+                    colspans(4, 2, 4, 2)),
+            Arguments.of(
+                    columns(null, null, 4, null),
+                    colspans(3, 3, 4, 2)),
+            Arguments.of(
+                    columns(null, null, 5, null),
+                    colspans(3, 2, 5, 2)),
+            Arguments.of(
+                    columns(null, null, 6, null),
+                    colspans(2, 2, 6, 2)),
+            Arguments.of(
+                    columns(null, null, 7, null),
+                    colspans(2, 2, 7, 1)),
+            Arguments.of(
+                    columns(null, null, 12, null),
+                    colspans(1, 1, 12, 1)),
+            Arguments.of(
+                    columns(null, null, null, null),
+                    colspans(3, 3, 3, 3)),
+            Arguments.of(
+                    columns(3, null, null, null, 2),
+                    colspans(3, 3, 2, 2, 2)),
+            Arguments.of(
+                    columns(null, 12),
+                    colspans(1, 12)),
+            Arguments.of(
+                    columns(null, 15, null, null),
+                    colspans(1, 15, 1, 1)),
+            Arguments.of(
+                    columns(null, 11, null, null),
+                    colspans(1, 11, 1, 1)),
+            Arguments.of(
+                    columns(1, 2, 3, 4),
+                    colspans(1, 2, 3, 4)),
+            Arguments.of(
+                    columns(20),
+                    colspans(20))
+    );
+  }
+
+  private static Stream<List<Integer>> inputColumns() {
+    return inputColumnsAndExpectedComputedColspans()
+            .map(args -> args.get()[0])
+            .map(arg -> (List<Integer>) arg);
+  }
+
+  private static List<Integer> columns(Integer... columns) {
+    return Arrays.asList(columns);
+  }
+
+  private static List<Integer> colspans(int... colspans) {
+    return IntStream.of(colspans).boxed().toList();
+  }
+
+  @ParameterizedTest
+  @MethodSource("inputColumnsAndExpectedComputedColspans")
+  void shouldCalculateColspans(List<Integer> inputColumns, List<Integer> expectedColspans) {
+    // validate input
+    assertThat(inputColumns).hasSameSizeAs(expectedColspans);
+    for (int i = 0; i < inputColumns.size(); i++) {
+      Integer columns = inputColumns.get(i);
+      if (columns != null) {
+        int colspan = expectedColspans.get(i);
+        assertThat(columns)
+                .describedAs("If columns field was specified for a cell, " +
+                        "then result colspan for that cell must never change")
+                .isEqualTo(colspan);
+      }
+    }
+
+    // given
+    Resource tableRow = createSingleRowTable(inputColumns, false);
+
+    // when
+    List<Integer> actualColspans = retrieveColspansOfCells(tableRow);
+
+    // then
+    assertThat(actualColspans).isEqualTo(expectedColspans);
+  }
+
+  @ParameterizedTest
+  @MethodSource("inputColumns")
+  void shouldNotCalculateColspans_IfTableIsScrollable(List<Integer> inputColumns) {
+    // given
+    Resource tableRow = createSingleRowTable(inputColumns, true);
+
+    // when
+    List<Integer> actualColspans = retrieveColspansOfCells(tableRow);
+
+    // then: expect colspan=1 for all cells that didn't have columns field specified
+    List<Integer> expectedColspans = inputColumns.stream()
+            .map(columns -> columns == null ? 1 : columns)
+            .toList();
+    assertThat(actualColspans).isEqualTo(expectedColspans);
+  }
+
+  /**
+   * @return parent table row
+   */
+  private Resource createSingleRowTable(List<Integer> columnsValues, boolean isScrollable) {
+    Resource table = context.create().resource("/content/table", Map.of("isScrollable", isScrollable));
+    Resource tableHead = context.create().resource(table, "tablehead");
+    Resource tableRow = context.create().resource(tableHead, "tablerow");
+    for (Integer columns : columnsValues) {
+        createCell(tableRow, columns);
+    }
+    return tableRow;
+  }
+
+  private void createCell(Resource parentRow, Integer columns) {
+    String name = "cell_" + RandomStringUtils.randomAlphanumeric(10);
+    Map<String, Object> properties = columns == null
+            ? Collections.emptyMap()
+            : Map.of("columns", columns);
+    context.create().resource(parentRow, name, properties);
+  }
+
+  private List<Integer> retrieveColspansOfCells(Resource tableRow) {
+    return StreamSupport
+            .stream(tableRow.getChildren().spliterator(), false)
+            .map(cell -> cell.adaptTo(TableCellComponent.class))
+            .map(TableCellComponent::getColspan)
+            .toList();
+  }
+
+}

--- a/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableComponentTest.java
+++ b/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableComponentTest.java
@@ -19,13 +19,20 @@ package pl.ds.kyanite.common.components.models.table;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.collections4.IterableUtils;
+import org.apache.sling.api.resource.Resource;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
 import org.apache.sling.testing.mock.sling.junit5.SlingContext;
 import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import pl.ds.kyanite.common.components.models.table.TableComponent;
 
 @ExtendWith(SlingContextExtension.class)
 public class TableComponentTest {
@@ -37,14 +44,17 @@ public class TableComponentTest {
   @BeforeEach
   public void init() {
     context.addModelsForClasses(TableComponent.class);
-    context.load().json(requireNonNull(
-        Thread.currentThread().getContextClassLoader().getResourceAsStream("table.json")), PATH);
   }
 
   @Test
   void defaultTableComponentModelTest() {
-    TableComponent model = context.resourceResolver().getResource(PATH + "/default")
-        .adaptTo(TableComponent.class);
+    // given
+    importTestTableResource();
+
+    // when
+    TableComponent model = toTableModel(PATH + "/default");
+
+    // then
     assertThat(model).isNotNull();
     assertThat(model.getTableClasses()).isEmpty();
     assertThat(model.isScrollable()).isFalse();
@@ -52,10 +62,61 @@ public class TableComponentTest {
 
   @Test
   void tableComponentTest() {
-    TableComponent model = context.resourceResolver().getResource(PATH + "/complex")
-        .adaptTo(TableComponent.class);
+    // given
+    importTestTableResource();
+
+    // when
+    TableComponent model = toTableModel(PATH + "/complex");
+
+    // then
     assertThat(model.isScrollable()).isTrue();
     assertThat(model.getTableClasses()).containsExactlyInAnyOrder("is-bordered", "is-striped",
         "is-narrow", "is-hoverable", "is-fullwidth", "is-scrollable");
+  }
+
+  @Test
+  void shouldCalculateInitialColspansForTableTemplate() throws IOException {
+    // given
+    String jcrPath = "/content/table/template";
+    importMainTableTemplateResource(jcrPath);
+
+    // when
+    toTableModel(jcrPath);
+
+    // then
+    Resource tableResource = context.resourceResolver().getResource(jcrPath);
+    List<Resource> tableCellResources = new ArrayList<>();
+    for (Resource tableHeadOrBody : IterableUtils.toList(tableResource.getChildren())) {
+      for (Resource tableRow : IterableUtils.toList(tableHeadOrBody.getChildren())) {
+        tableCellResources.addAll(IterableUtils.toList(tableRow.getChildren()));
+      }
+    }
+
+    // currently the template for table is 3 rows x 3 columns
+    assertThat(tableCellResources)
+            .hasSize(9)
+            .extracting(cell -> cell.adaptTo(TableCellComponent.class))
+            .extracting(TableCellComponent::getColspan)
+            .allMatch(colspan -> colspan.equals(4)); // 4, because currently default summary colspan of each row is 12
+  }
+
+  private void importTestTableResource() {
+    context.load().json(requireNonNull(
+            Thread.currentThread().getContextClassLoader().getResourceAsStream("table.json")), PATH);
+  }
+
+  private void importMainTableTemplateResource(String jcrPath) throws IOException {
+    File tableTemplateFile = new File("src/main/resources/libs/kyanite/common/components/table/template/.content.json");
+    assertThat(tableTemplateFile).exists();
+
+    try (InputStream fileStream = new FileInputStream(tableTemplateFile)) {
+      context.load().json(fileStream, jcrPath);
+    }
+  }
+
+  private TableComponent toTableModel(String tableResourcePath) {
+    return context.resourceResolver()
+            .getResource(tableResourcePath)
+            .adaptTo(TableComponent.class);
   }
 }

--- a/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableHeadCellComponentTest.java
+++ b/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableHeadCellComponentTest.java
@@ -25,7 +25,6 @@ import org.apache.sling.testing.mock.sling.junit5.SlingContextExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import pl.ds.kyanite.common.components.models.table.TableHeadCellComponent;
 
 @ExtendWith(SlingContextExtension.class)
 public class TableHeadCellComponentTest {
@@ -48,8 +47,8 @@ public class TableHeadCellComponentTest {
         .adaptTo(TableHeadCellComponent.class);
     assertThat(model).isNotNull();
     assertThat(model.getText()).isEqualTo("Content");
-    assertThat(model.getRows()).isEqualTo(1);
-    assertThat(model.getColumns()).isEqualTo(1);
+    assertThat(model.getRowspan()).isEqualTo(1);
+    assertThat(model.getColspan()).isEqualTo(12);
   }
 
   @Test
@@ -57,7 +56,7 @@ public class TableHeadCellComponentTest {
     TableHeadCellComponent model = context.resourceResolver().getResource(PATH + "/tablehead/tablerow2/complex")
         .adaptTo(TableHeadCellComponent.class);
     assertThat(model.getText()).isEqualTo("Table head cell text");
-    assertThat(model.getRows()).isEqualTo(2);
-    assertThat(model.getColumns()).isEqualTo(3);
+    assertThat(model.getRowspan()).isEqualTo(2);
+    assertThat(model.getColspan()).isEqualTo(3);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Calculation of colspans for table cells

## Description
<!--- Describe your changes in detail -->
The mechanism is active only for non-scrollable tables.

It "automatically" rescales cells that don't have Columns property explicitly set by Author, so that the cells fit the available space in as best as possible way. The default table width is 12 "colspan points".

## Motivation and Context
The change aims at improving Author's experience with the Table component
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
🔺 Unsure if this feature should be mentioned in the documentation 💭 