### PR TITLE
KYAN-242 stabilize navbar visual tests

### DIFF
--- a/tests/end-to-end/backstop.js
+++ b/tests/end-to-end/backstop.js
@@ -48,8 +48,8 @@ const getPublishedPageUrl = ({ space, page }) => {
 
 const spaces = ['kyanite-visual-tests', 'kyanite-visual-tests-dark-mode'];
 
-const postHoverInterval = 1000;
-const postClickInterval = 1000;
+const postHoverIntervalMs = 1000;
+const postClickIntervalMs = 1000;
 
 const scenarios = spaces.flatMap(space => [
   { space: space, page: 'icons' },
@@ -67,22 +67,22 @@ const scenarios = spaces.flatMap(space => [
   { space: space, page: 'navbar', selectors: [selectors.body],
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
-    postInteractionWait: postHoverInterval,
+    postInteractionWait: postHoverIntervalMs,
   },
   { space: space, page: 'navbar-megadropdown', selectors: [selectors.body],
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
-    postInteractionWait: postHoverInterval,
+    postInteractionWait: postHoverIntervalMs,
   },
   { space: space, page: 'navbar-megadropdown', selectors: [selectors.body],
     clickSelectors: ['.navbar-burger', '.navbar-item.has-dropdown'],
     viewports: viewports.filter((viewport) => ['md-mini', 'md'].includes(viewport.label)),
-    postInteractionWait: postClickInterval,
+    postInteractionWait: postClickIntervalMs,
   },
   { space: space, page: 'navbar-megadropdown-columns', selectors: [selectors.body],
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
-    postInteractionWait: postHoverInterval,
+    postInteractionWait: postHoverIntervalMs,
   },
   { space: space, page: 'blog-article-header/blog-article-page', selectors: [selectors.container] },
   { space: space, page: 'blog-listing', selectors: [selectors.container] },
@@ -103,13 +103,13 @@ const scenarios = spaces.flatMap(space => [
     label: `${space}_external-link-meganav`,
     clickSelector: '.navbar-item.has-dropdown.is-hoverable',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
-    postInteractionWait: postClickInterval,
+    postInteractionWait: postClickIntervalMs,
   },
   { space: space, page: 'navbar-external-links', selectors: [selectors.body],
     label: `${space}_external-link-dropdown-menu`,
     clickSelector: '.navbar-item.has-dropdown.is-hoverable:nth-of-type(2)',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
-    postInteractionWait: postClickInterval,
+    postInteractionWait: postClickIntervalMs,
   },
   { space: space, page: 'container/container-alignment',  selectors: [ selectors.container] },
   { space: space, page: 'level/level-item-alignment',     selectors: [ selectors.all] },

--- a/tests/end-to-end/backstop.js
+++ b/tests/end-to-end/backstop.js
@@ -48,6 +48,9 @@ const getPublishedPageUrl = ({ space, page }) => {
 
 const spaces = ['kyanite-visual-tests', 'kyanite-visual-tests-dark-mode'];
 
+const postHoverInterval = 1000;
+const postClickInterval = 1000;
+
 const scenarios = spaces.flatMap(space => [
   { space: space, page: 'icons' },
   { space: space, page: 'heading-typography', selectors: [selectors.container] },
@@ -63,20 +66,23 @@ const scenarios = spaces.flatMap(space => [
   { space: space, page: 'navbar', selectors: [selectors.header] },
   { space: space, page: 'navbar', selectors: [selectors.body],
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
-    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label))
+    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
+    postInteractionWait: postHoverInterval,
   },
   { space: space, page: 'navbar-megadropdown', selectors: [selectors.body],
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
-    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label))
+    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
+    postInteractionWait: postHoverInterval,
   },
   { space: space, page: 'navbar-megadropdown', selectors: [selectors.body],
     clickSelectors: ['.navbar-burger', '.navbar-item.has-dropdown'],
     viewports: viewports.filter((viewport) => ['md-mini', 'md'].includes(viewport.label)),
-    postInteractionWait: 1000,
+    postInteractionWait: postClickInterval,
   },
   { space: space, page: 'navbar-megadropdown-columns', selectors: [selectors.body],
     hoverSelector: '.navbar-item.has-dropdown.is-hoverable',
-    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label))
+    viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
+    postInteractionWait: postHoverInterval,
   },
   { space: space, page: 'blog-article-header/blog-article-page', selectors: [selectors.container] },
   { space: space, page: 'blog-listing', selectors: [selectors.container] },
@@ -97,11 +103,13 @@ const scenarios = spaces.flatMap(space => [
     label: `${space}_external-link-meganav`,
     clickSelector: '.navbar-item.has-dropdown.is-hoverable',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
+    postInteractionWait: postClickInterval,
   },
   { space: space, page: 'navbar-external-links', selectors: [selectors.body],
     label: `${space}_external-link-dropdown-menu`,
     clickSelector: '.navbar-item.has-dropdown.is-hoverable:nth-of-type(2)',
     viewports: viewports.filter((viewport) => ['lg', 'xl', 'mx'].includes(viewport.label)),
+    postInteractionWait: postClickInterval,
   },
   { space: space, page: 'container/container-alignment',  selectors: [ selectors.container] },
   { space: space, page: 'level/level-item-alignment',     selectors: [ selectors.all] },


### PR DESCRIPTION
Navbar visual tests are stabilized by adding a post-action interval (default 1s interval was taken).
Before this fix visual tests involving clicking/hovering elements would give random results. 
This approach should be used for any hover/click/etc.-based visual tests

## Motivation and Context
https://teamds.atlassian.net/browse/KYAN-242

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
