### PR TITLE
KYAN-242 'stabilize' blog listing visual tests

### DIFF
--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-listing/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-listing/.content.xml
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:ws="http://ds.pl/websight" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-    jcr:primaryType="ws:Page">
+<jcr:root   xmlns:jcr="http://www.jcp.org/jcr/1.0"
+            xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+            xmlns:ws="http://ds.pl/websight"
+            xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+        jcr:primaryType="ws:Page">
     <jcr:content
-        jcr:lastModified="{Date}2023-05-29T14:41:44.151Z"
-        jcr:lastModifiedBy="wsadmin"
-        jcr:primaryType="ws:PageContent"
-        jcr:title="Blog listing"
-        sling:resourceType="kyanite/common/components/page"
-        ws:lastModified="{Date}2023-05-30T14:01:23.756Z"
-        ws:lastModifiedBy="wsadmin"
-        ws:template="/libs/kyanite/blogs/templates/bloglistingpage"
-        navbarFixed="false"
-        navbarFixedPosition="has-navbar-fixed-top">
+            jcr:primaryType="ws:PageContent"
+            jcr:title="Blog listing"
+            sling:resourceType="kyanite/common/components/page"
+            ws:template="/libs/kyanite/blogs/templates/bloglistingpage"
+            navbarFixed="false"
+            navbarFixedPosition="has-navbar-fixed-top">
         <pagecontainer
-            jcr:primaryType="nt:unstructured"
-            sling:resourceType="kyanite/common/components/pagecontainer">
-            <container
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/container">
-                <section
+                sling:resourceType="kyanite/common/components/pagecontainer">
+            <container
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
-                    <featuredblogarticle
+                    sling:resourceType="kyanite/common/components/container">
+                <section
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="kyanite/blogs/components/featuredblogarticle"/>
+                        sling:resourceType="kyanite/common/components/section" renderAsHero="false">
+                    <featuredblogarticle
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/blogs/components/featuredblogarticle"
+                            link="/content/kyanite-visual-tests/pages/blog-listing/blog-article-2"/>
                     <bloglist
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="kyanite/blogs/components/bloglist">
+                            sling:resourceType="kyanite/blogs/components/bloglist"
+                            link="/content/kyanite-visual-tests/pages/blog-listing">
                         <author
                                 jcr:primaryType="nt:unstructured"
                                 authorInfoSource="parentPage"/>
@@ -34,8 +35,9 @@
                 </section>
             </container>
             <bloglist
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/blogs/components/bloglist"/>
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kyanite/blogs/components/bloglist"
+                    link="/content/kyanite-visual-tests/pages/blog-listing"/>
         </pagecontainer>
     </jcr:content>
     <blog-article-1/>

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-listing/blog-article-2/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests-dark-mode/pages/blog-listing/blog-article-2/.content.xml
@@ -2,13 +2,9 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:ws="http://ds.pl/websight" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="ws:Page">
     <jcr:content
-        jcr:lastModified="{Date}2023-05-29T14:42:14.015Z"
-        jcr:lastModifiedBy="wsadmin"
         jcr:primaryType="ws:PageContent"
         jcr:title="Blog article 2"
         sling:resourceType="kyanite/blogs/components/blogarticlepage"
-        ws:lastModified="{Date}2023-05-30T09:04:42.420Z"
-        ws:lastModifiedBy="wsadmin"
         ws:template="/libs/kyanite/blogs/templates/blogarticlepage"
         description="\0"
         heroImage="/content/kyanite-visual-tests/assets/blog-image-example.jpeg/"
@@ -19,10 +15,12 @@
         readTime="4"
         title="Revolutionize Customer Engagement with a DXP">
         <author
-                jcr:primaryType="nt:unstructured"
-                authorInfoSource="ownProperties"
-                authorName="John Doe"
-                authorPhotoAlt="\0"/>
+            jcr:primaryType="nt:unstructured"
+            authorDescription="\0"
+            authorInfoSource="ownProperties"
+            authorName="John Doe"
+            authorPhotoAlt="\0"
+            authorRole="\0"/>
         <pagecontainer
             jcr:primaryType="nt:unstructured"
             sling:resourceType="kyanite/common/components/pagecontainer">
@@ -33,5 +31,13 @@
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/footerreference"/>
         </pagecontainer>
+        <tags jcr:primaryType="nt:unstructured">
+            <_x0030_
+                jcr:primaryType="nt:unstructured"
+                text="tag1"/>
+            <_x0031_
+                jcr:primaryType="nt:unstructured"
+                text="tag2"/>
+        </tags>
     </jcr:content>
 </jcr:root>

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-listing/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-listing/.content.xml
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:ws="http://ds.pl/websight" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-    jcr:primaryType="ws:Page">
+<jcr:root   xmlns:jcr="http://www.jcp.org/jcr/1.0"
+            xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+            xmlns:ws="http://ds.pl/websight"
+            xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+        jcr:primaryType="ws:Page">
     <jcr:content
-        jcr:lastModified="{Date}2023-05-29T14:41:44.151Z"
-        jcr:lastModifiedBy="wsadmin"
-        jcr:primaryType="ws:PageContent"
-        jcr:title="Blog listing"
-        sling:resourceType="kyanite/common/components/page"
-        ws:lastModified="{Date}2023-05-30T14:01:23.756Z"
-        ws:lastModifiedBy="wsadmin"
-        ws:template="/libs/kyanite/blogs/templates/bloglistingpage"
-        navbarFixed="false"
-        navbarFixedPosition="has-navbar-fixed-top">
+            jcr:primaryType="ws:PageContent"
+            jcr:title="Blog listing"
+            sling:resourceType="kyanite/common/components/page"
+            ws:template="/libs/kyanite/blogs/templates/bloglistingpage"
+            navbarFixed="false"
+            navbarFixedPosition="has-navbar-fixed-top">
         <pagecontainer
-            jcr:primaryType="nt:unstructured"
-            sling:resourceType="kyanite/common/components/pagecontainer">
-            <container
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/common/components/container">
-                <section
+                sling:resourceType="kyanite/common/components/pagecontainer">
+            <container
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="kyanite/common/components/section" renderAsHero="false">
+                    sling:resourceType="kyanite/common/components/container">
+                <section
+                        jcr:primaryType="nt:unstructured"
+                        sling:resourceType="kyanite/common/components/section" renderAsHero="false">
                     <featuredblogarticle
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="kyanite/blogs/components/featuredblogarticle"/>
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/blogs/components/featuredblogarticle"
+                            link="/content/kyanite-visual-tests/pages/blog-listing/blog-article-2"/>
                     <bloglist
-                        jcr:primaryType="nt:unstructured"
-                        sling:resourceType="kyanite/blogs/components/bloglist">
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="kyanite/blogs/components/bloglist"
+                            link="/content/kyanite-visual-tests/pages/blog-listing">
                         <author
                                 jcr:primaryType="nt:unstructured"
                                 authorInfoSource="parentPage"/>
@@ -34,8 +35,9 @@
                 </section>
             </container>
             <bloglist
-                jcr:primaryType="nt:unstructured"
-                sling:resourceType="kyanite/blogs/components/bloglist"/>
+                    jcr:primaryType="nt:unstructured"
+                    sling:resourceType="kyanite/blogs/components/bloglist"
+                    link="/content/kyanite-visual-tests/pages/blog-listing"/>
         </pagecontainer>
     </jcr:content>
     <blog-article-1/>

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-listing/blog-article-2/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-listing/blog-article-2/.content.xml
@@ -2,13 +2,9 @@
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:ws="http://ds.pl/websight" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
     jcr:primaryType="ws:Page">
     <jcr:content
-        jcr:lastModified="{Date}2023-05-29T14:42:14.015Z"
-        jcr:lastModifiedBy="wsadmin"
         jcr:primaryType="ws:PageContent"
         jcr:title="Blog article 2"
         sling:resourceType="kyanite/blogs/components/blogarticlepage"
-        ws:lastModified="{Date}2023-05-30T09:04:42.420Z"
-        ws:lastModifiedBy="wsadmin"
         ws:template="/libs/kyanite/blogs/templates/blogarticlepage"
         description="\0"
         heroImage="/content/kyanite-visual-tests/assets/blog-image-example.jpeg/"
@@ -19,10 +15,12 @@
         readTime="4"
         title="Revolutionize Customer Engagement with a DXP">
         <author
-                jcr:primaryType="nt:unstructured"
-                authorInfoSource="ownProperties"
-                authorName="John Doe"
-                authorPhotoAlt="\0"/>
+            jcr:primaryType="nt:unstructured"
+            authorDescription="\0"
+            authorInfoSource="ownProperties"
+            authorName="John Doe"
+            authorPhotoAlt="\0"
+            authorRole="\0"/>
         <pagecontainer
             jcr:primaryType="nt:unstructured"
             sling:resourceType="kyanite/common/components/pagecontainer">
@@ -33,5 +31,13 @@
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="kyanite/common/components/footerreference"/>
         </pagecontainer>
+        <tags jcr:primaryType="nt:unstructured">
+            <_x0030_
+                jcr:primaryType="nt:unstructured"
+                text="tag1"/>
+            <_x0031_
+                jcr:primaryType="nt:unstructured"
+                text="tag2"/>
+        </tags>
     </jcr:content>
 </jcr:root>


### PR DESCRIPTION
Visual tests for 'Blog listing' page were inconsistent, because Blog Listing and Featured Article contents changed every time we added a new Blog Article Page to visual tests space. This randomness was eliminated by specifying paths: 
- page path for Featured Article component. I've chosen a page that is not the first or last alphabetically or by creation time and added tags to it to be displayed by FA component
- articles root for Blog Listing component

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://teamds.atlassian.net/browse/KYAN-242

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
