### PR TITLE
KYAN-242 fix tablet viewport definition in visual tests

### DIFF
--- a/tests/end-to-end/backstop.js
+++ b/tests/end-to-end/backstop.js
@@ -32,7 +32,7 @@ const selectors = {
 
 const viewports = [
   { label: 'md-mini', width: 360,  height: 480  },
-  { label: 'md',      width: 768,  height: 1024 },
+  { label: 'md',      width: 769,  height: 1024 },
   { label: 'lg',      width: 1025, height: 768  },
   { label: 'xl',      width: 1216, height: 1024 },
   { label: 'mx',      width: 1408, height: 900  }


### PR DESCRIPTION
Tablet viewport definition was corrected for our visual tests to cover tablet screen size.

During the 'migration' related to this fix, i.e. when performing visual check on the fix branch against pre-fix main branch, we will get two types of fails:
- 1px width difference
- content layout difference
Those a related to a fact that, for 'md' viewport, 'main' branch will capture screenshots for 768px width pages, which corresponds to mobile, and fix branch will have screenshots for 769px width pages (tablet).

Differences that are not related to tablet viewport were fixed by [navbar PR](https://github.com/websight-io/kyanite/pull/466) and [blog listing PR](https://github.com/websight-io/kyanite/pull/467).

**No differences of other nature were discovered.**

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://teamds.atlassian.net/browse/KYAN-242

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
