### PR TITLE
WSIO-643 remove keywords meta tag from page

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head.html
@@ -20,7 +20,6 @@
   <sly data-sly-include="head-start.html"></sly>
   <meta charset="UTF-8">
   <title>${properties.title ? properties.title : properties.jcr:title}</title>
-  <meta data-sly-test.keywords="${properties.title}" name="keywords" content="${keywords}">
   <meta data-sly-test.description="${properties.description}" name="description"
         content="${description}">
 


### PR DESCRIPTION
'keywords' tag was removed from Kyanite Page as it's not used by serach engine and rather harmful than helpful.

## Motivation and Context
https://teamds.atlassian.net/browse/WSIO-643

## Screenshots (if appropriate)
The output of a page with Metadata/title and Metadata/description filled with values
![image](https://github.com/websight-io/kyanite/assets/13979207/22fce297-0ded-4af1-972b-49767f74a41f)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
