### PR TITLE
Kyan 245 hero dynamic title text wrap improvements needed

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/TitleComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/TitleComponent.java
@@ -118,6 +118,10 @@ public class TitleComponent {
 
   @Inject
   @Getter
+  private String noTitleWrapping;
+
+  @Inject
+  @Getter
   private Integer speed;
 
   @Inject

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/dialog/.content.json
@@ -177,6 +177,13 @@
 					"label": "Show typed text cursor?",
 					"default": "false"
 				},
+				"noTitleWrapping": {
+					"sling:resourceType": "wcm/dialogs/components/checkbox",
+					"name": "noTitleWrapping",
+					"label": "Disable text wrapping by reducing the font size (mobile only)",
+					"description": "Not recommended for long endings",
+					"default": "false"
+				},
 				"ws:display": {
 					"condition": {
 						"sourceName": "addAnimatedEndings",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/template/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/template/.content.json
@@ -7,6 +7,7 @@
 	"size": "is-2",
 	"addAnimatedEndings": false,
 	"showCursor": false,
+	"noTitleWrapping": false,
 	"speed": 50,
 	"delay": 1200
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/title.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/title.html
@@ -55,7 +55,7 @@
             </sly>
           </sly>
         <!--/* end */-->
-        <span class="${model.endingsClasses @ join=' '} typed-animation" data-show-cursor="${model.showCursor}" data-endings="${model.endingJson}" data-speed="${model.speed}" data-delay="${model.delay}">
+        <span class="${model.endingsClasses @ join=' '} typed-animation" data-no-title-wrapping="${model.noTitleWrapping}" data-show-cursor="${model.showCursor}" data-endings="${model.endingJson}" data-speed="${model.speed}" data-delay="${model.delay}">
         </span>
         <sly data-sly-test="${!model.showCursor}"><span class="typed-cursor" style="visibility: hidden" aria-hidden="true">|</span></sly>
       </div>

--- a/applications/common/frontend/src/components/Title/animatedEndings.class.ts
+++ b/applications/common/frontend/src/components/Title/animatedEndings.class.ts
@@ -14,13 +14,43 @@
  * limitations under the License.
  */
 
+import { breakpoints } from 'src/helpers/breakpoints';
 import Typed from 'typed.js';
+
+/**
+ * Helper function which takes the longest from all endings and check in each iteration if it fits in one line.
+ * It uses already rendered endings (in html for SEO purposes) to take the longest element and test height.
+ *
+ * @param titleEl Title html element to which font-size is applied
+ * @param currentSize current size of the title element, desreasing in each iteration by one pixel
+ * @param lineHeight Desired height of the animated ending (max height)
+ *
+ */
+const adjustTitleFontSize = (
+  titleEl: HTMLElement,
+  currentSize: number,
+  lineHeight: number
+) => {
+  titleEl.style.fontSize = currentSize + 'px';
+  const heights = Array.from(
+    titleEl.querySelectorAll('.container-with-endings > span')
+  ).map((ending) => {
+    return ending.clientHeight;
+  });
+  const longestEnding = Math.max(...heights);
+  if (longestEnding > lineHeight) {
+    adjustTitleFontSize(titleEl, currentSize - 1, lineHeight);
+  } else {
+    return;
+  }
+};
 
 export class AnimatedEndings {
   static readonly SELECTOR = '.typed-animation';
   public readonly element: HTMLElement;
   public readonly titleElement: HTMLElement;
   public readonly showCursor: boolean;
+  public readonly noTitleWrapping: boolean;
   public readonly speed: number;
   public readonly delay: number;
   public readonly strings: string[];
@@ -29,6 +59,7 @@ export class AnimatedEndings {
     this.element = element;
     this.titleElement = title;
     this.showCursor = JSON.parse(element.dataset.showCursor);
+    this.noTitleWrapping = JSON.parse(element.dataset.noTitleWrapping);
     this.speed = Number(element.dataset.speed);
     this.delay = Number(element.dataset.delay);
     this.strings = JSON.parse(element.dataset.endings);
@@ -50,10 +81,16 @@ export class AnimatedEndings {
       },
     });
 
-    AnimatedEndings.setHeightOfTitle(this.titleElement); // will be overwritten in onload event (to avoid jumping, onload needed for Safari bug)
-    window.onresize = () => {
-      AnimatedEndings.setHeightOfTitle(this.titleElement);
-    };
+    if (this.noTitleWrapping) {
+      window.onresize = () => {
+        AnimatedEndings.setFontSize(this.titleElement);
+      };
+    } else {
+      AnimatedEndings.setHeightOfTitle(this.titleElement); // will be overwritten in onload event (to avoid jumping, onload needed for Safari bug)
+      window.onresize = () => {
+        AnimatedEndings.setHeightOfTitle(this.titleElement);
+      };
+    }
   }
 
   static setHeightOfTitle(titleEl: HTMLElement) {
@@ -65,5 +102,20 @@ export class AnimatedEndings {
     const titleContainer: HTMLElement =
       titleEl.querySelector('.title-container');
     titleContainer.style.height = Math.max(...heights) + 'px';
+  }
+
+  static setFontSize(titleEl: HTMLElement) {
+    if (window.matchMedia(`(max-width: ${breakpoints.md}px)`).matches) {
+      const currentSize = Number(
+        window.getComputedStyle(titleEl).fontSize.split('px')[0]
+      );
+      const lineHeight = Number(
+        window.getComputedStyle(titleEl).lineHeight.split('px')[0]
+      );
+
+      if (!isNaN(currentSize) && !isNaN(lineHeight)) {
+        adjustTitleFontSize(titleEl, currentSize, lineHeight);
+      }
+    }
   }
 }

--- a/applications/common/frontend/src/components/Title/animatedEndings.class.ts
+++ b/applications/common/frontend/src/components/Title/animatedEndings.class.ts
@@ -106,15 +106,15 @@ export class AnimatedEndings {
 
   static setFontSize(titleEl: HTMLElement) {
     if (window.matchMedia(`(max-width: ${breakpoints.md}px)`).matches) {
-      const currentSize = Number(
+      const initialSize = Number(
         window.getComputedStyle(titleEl).fontSize.split('px')[0]
       );
       const lineHeight = Number(
         window.getComputedStyle(titleEl).lineHeight.split('px')[0]
       );
 
-      if (!isNaN(currentSize) && !isNaN(lineHeight)) {
-        adjustTitleFontSize(titleEl, currentSize, lineHeight);
+      if (!isNaN(initialSize) && !isNaN(lineHeight)) {
+        adjustTitleFontSize(titleEl, initialSize, lineHeight);
       }
     }
   }

--- a/applications/common/frontend/src/components/Title/title.ts
+++ b/applications/common/frontend/src/components/Title/title.ts
@@ -40,8 +40,8 @@ const setAnimatedEndingsHeight = () => {
         ).forEach((animatedEndingsEl: HTMLElement) => {
           const noTitleWrapping = animatedEndingsEl.dataset.noTitleWrapping;
 
-          if (noTitleWrapping) {
-            AnimatedEndings.setFontSize(component); // different values when onDomContentLoaded 
+          if (JSON.parse(noTitleWrapping)) {
+            AnimatedEndings.setFontSize(component); // different values when onDomContentLoaded
           } else {
             AnimatedEndings.setHeightOfTitle(component);
           }

--- a/applications/common/frontend/src/components/Title/title.ts
+++ b/applications/common/frontend/src/components/Title/title.ts
@@ -37,8 +37,14 @@ const setAnimatedEndingsHeight = () => {
       (component: HTMLElement) => {
         Array.from(
           component.querySelectorAll(AnimatedEndings.SELECTOR)
-        ).forEach(() => {
-          AnimatedEndings.setHeightOfTitle(component);
+        ).forEach((animatedEndingsEl: HTMLElement) => {
+          const noTitleWrapping = animatedEndingsEl.dataset.noTitleWrapping;
+
+          if (noTitleWrapping) {
+            AnimatedEndings.setFontSize(component); // different values when onDomContentLoaded 
+          } else {
+            AnimatedEndings.setHeightOfTitle(component);
+          }
         });
       }
     );


### PR DESCRIPTION
[KYAN-245](https://teamds.atlassian.net/browse/KYAN-245)

## Description
After some consideration I propose following solution:

add checkbox under “animated endings“ tab called “Disable text wrapping by reducing the font size (mobile viewports only)“. And as the description said, the whole  title will shrink to fit only one line at mobile viewport. If there will be a need, we can expand this feature to tablet also (first need viewport is mobile for sure).

Option has to be enabled manually since I want to be sure that author knows what it can cause - when option is enabled and when adding really long ending, the whole title will shrink and can be even smaller than the description text below. I will add label with Not recommended for really long endings . 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.


[KYAN-245]: https://teamds.atlassian.net/browse/KYAN-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ