### PR TITLE
WSIO-1182 We shouldn't run GTM scripts in page editor

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head-libs.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head-libs.html
@@ -17,6 +17,7 @@
 */-->
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.PageHeadLibsComponent"></sly>
+<sly data-sly-test="${wcmmode.isDisabled}">
 <!-- Google Tag Manager -->
 <script data-sly-test="${model.hasAnalyticsUrl}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -24,6 +25,7 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','${model.googleAnalyticsTrackingId @ context="text"}');</script>
 <!-- End Google Tag Manager -->
+</sly>
 
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
GMT scripts can break the Page Editor. Additionally, we track the information from the Page Editor and that makes no sens.

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
