### PR TITLE
WSIO-733 Enable configuring icons in table cells

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableCellComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableCellComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Dynamic Solutions
+ * Copyright (C) 2024 Dynamic Solutions
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,12 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceUtil;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
+import org.apache.sling.models.annotations.injectorspecific.ChildResource;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import pl.ds.kyanite.common.components.models.table.dto.TableCellData;
 import pl.ds.kyanite.common.components.models.table.dto.TableRowData;
 
@@ -52,6 +55,12 @@ public class TableCellComponent {
   @SlingObject
   private Resource currentResource;
 
+  @ValueMapValue
+  private String iconVariant;
+
+  @ChildResource(name = "embeddedIcon")
+  private Resource iconResource;
+
   @PostConstruct
   private void init() {
     if (StringUtils.isEmpty(text)) {
@@ -69,10 +78,10 @@ public class TableCellComponent {
 
   private int computeColspan() {
     Optional<TableComponent> parentTable = Optional
-            .ofNullable(currentResource.getParent()) // table row
-            .map(Resource::getParent) // table head or body
-            .map(Resource::getParent) // the table
-            .map(tableResource -> tableResource.adaptTo(TableComponent.class));
+        .ofNullable(currentResource.getParent()) // table row
+        .map(Resource::getParent) // table head or body
+        .map(Resource::getParent) // the table
+        .map(tableResource -> tableResource.adaptTo(TableComponent.class));
 
     if (parentTable.isEmpty() || parentTable.get().isScrollable()) {
       return DEFAULT_COLSPAN;
@@ -81,11 +90,11 @@ public class TableCellComponent {
     Resource parentRow = currentResource.getParent();
 
     List<TableCellData> tableCells = StreamSupport
-            .stream(parentRow.getChildren().spliterator(), false)
-            .map(cell -> new TableCellData(
-                    cell.getValueMap().get("columns", Integer.class),
-                    cell.getPath().equals(currentResource.getPath())))
-            .toList();
+        .stream(parentRow.getChildren().spliterator(), false)
+        .map(cell -> new TableCellData(
+            cell.getValueMap().get("columns", Integer.class),
+            cell.getPath().equals(currentResource.getPath())))
+        .toList();
 
     TableRowData tableRowData = new TableRowData(tableCells);
 
@@ -93,36 +102,36 @@ public class TableCellComponent {
   }
 
   /**
-   * Computes colspan for a cell that hasn't got the columns property specified.
-   * Attempts to give each such cell the same colspan, if possible.
-   * It takes into account colspans from other cells in the same row.
+   * Computes colspan for a cell that hasn't got the columns property specified. Attempts to give
+   * each such cell the same colspan, if possible. It takes into account colspans from other cells
+   * in the same row.
    */
   private static int computeColspan(TableRowData row) {
     int summaryAvailableColspan = TableComponent.DEFAULT_SUMMARY_COLSPAN
-            - row.getSummaryColspanTakenByCellsWithColumnsSpecified();
+        - row.getSummaryColspanTakenByCellsWithColumnsSpecified();
 
     if (summaryAvailableColspan < 1) {
       return 1;
     }
 
     int colspanAvailableForSingleCell = summaryAvailableColspan
-            / row.getNumberOfCellsWithColumnsUnspecified();
+        / row.getNumberOfCellsWithColumnsUnspecified();
     if (colspanAvailableForSingleCell == 0) {
       colspanAvailableForSingleCell = 1;
     }
 
     if (summaryAvailableColspan
-            % row.getNumberOfCellsWithColumnsUnspecified() == 0) {
+        % row.getNumberOfCellsWithColumnsUnspecified() == 0) {
       // all cells are able to receive the same colspan
       return colspanAvailableForSingleCell;
     }
 
     // ... otherwise - we have some additional colspan space to distribute between cells
     int colspanLeftToDistribute = summaryAvailableColspan
-            - row.getNumberOfCellsWithColumnsUnspecified() * colspanAvailableForSingleCell;
+        - row.getNumberOfCellsWithColumnsUnspecified() * colspanAvailableForSingleCell;
 
     int indexOfCurrentCellInCellsWithColumnsUnspecified =
-            getIndexOfCurrentCellInCellsWithColumnsUnspecified(row.getTableCellData());
+        getIndexOfCurrentCellInCellsWithColumnsUnspecified(row.getTableCellData());
 
     if (indexOfCurrentCellInCellsWithColumnsUnspecified < colspanLeftToDistribute) {
       // when giving additional +1 to colspan, prefer cells from the left
@@ -133,7 +142,7 @@ public class TableCellComponent {
   }
 
   private static int getIndexOfCurrentCellInCellsWithColumnsUnspecified(
-          List<TableCellData> tableCells) {
+      List<TableCellData> tableCells) {
     int resultIndex = 0;
     for (TableCellData tableCell : tableCells) {
       if (tableCell.isCurrentCell()) {
@@ -147,4 +156,28 @@ public class TableCellComponent {
     throw new IllegalStateException("Expected to always find the current cell in cells list");
   }
 
+  public Optional<Resource> getLeftIcon() {
+    return getIcon(IconLayout.ON_THE_LEFT);
+  }
+
+  public Optional<Resource> getRightIcon() {
+    return getIcon(IconLayout.ON_THE_RIGHT);
+  }
+
+  private Optional<Resource> getIcon(final IconLayout iconLayout) {
+    return Optional.ofNullable(iconResource)
+        .filter(resource -> !ResourceUtil.isNonExistingResource(resource))
+        .filter(resource -> StringUtils.equalsIgnoreCase(iconLayout.variantName, iconVariant));
+  }
+
+  private enum IconLayout {
+    ON_THE_LEFT("icon-on-the-left"),
+    ON_THE_RIGHT("icon-on-the-right");
+
+    private final String variantName;
+
+    IconLayout(final String variantName) {
+      this.variantName = variantName;
+    }
+  }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableCellComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/table/TableCellComponent.java
@@ -16,6 +16,8 @@
 
 package pl.ds.kyanite.common.components.models.table;
 
+import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.StreamSupport;
@@ -39,6 +41,7 @@ import pl.ds.kyanite.common.components.models.table.dto.TableRowData;
 public class TableCellComponent {
 
   private static final String DEFAULT_TEXT = "Content";
+  private static final String PN_ICON_VARIANT = "iconVariant";
   private static final int DEFAULT_COLSPAN = 1;
   private static final int DEFAULT_ROWSPAN = 1;
 
@@ -56,7 +59,7 @@ public class TableCellComponent {
   private Resource currentResource;
 
   @ValueMapValue
-  private String iconVariant;
+  private String cellType = CellType.TEXT.name();
 
   @ChildResource(name = "embeddedIcon")
   private Resource iconResource;
@@ -66,6 +69,31 @@ public class TableCellComponent {
     if (StringUtils.isEmpty(text)) {
       text = DEFAULT_TEXT;
     }
+  }
+
+  public boolean isShowText() {
+    return equalsIgnoreCase(CellType.TEXT.name(), cellType);
+  }
+
+  public boolean isShowIcon() {
+    return equalsIgnoreCase(CellType.ICON.name(), cellType);
+  }
+
+  public Optional<Resource> getIcon() {
+    return Optional.ofNullable(iconResource)
+        .filter(resource -> !ResourceUtil.isNonExistingResource(resource));
+  }
+
+  public boolean isIconOnTheLeft() {
+    return !isIconOnTheRight();
+  }
+
+  public boolean isIconOnTheRight() {
+    return getIcon()
+        .map(Resource::getValueMap)
+        .map(valueMap -> valueMap.get(PN_ICON_VARIANT, IconLayout.ON_THE_LEFT.variantName))
+        .filter(iconLayout -> equalsIgnoreCase(IconLayout.ON_THE_RIGHT.variantName, iconLayout))
+        .isPresent();
   }
 
   public int getColspan() {
@@ -156,18 +184,9 @@ public class TableCellComponent {
     throw new IllegalStateException("Expected to always find the current cell in cells list");
   }
 
-  public Optional<Resource> getLeftIcon() {
-    return getIcon(IconLayout.ON_THE_LEFT);
-  }
-
-  public Optional<Resource> getRightIcon() {
-    return getIcon(IconLayout.ON_THE_RIGHT);
-  }
-
-  private Optional<Resource> getIcon(final IconLayout iconLayout) {
-    return Optional.ofNullable(iconResource)
-        .filter(resource -> !ResourceUtil.isNonExistingResource(resource))
-        .filter(resource -> StringUtils.equalsIgnoreCase(iconLayout.variantName, iconVariant));
+  private enum CellType {
+    TEXT,
+    ICON
   }
 
   private enum IconLayout {

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/dialog/.content.json
@@ -1,183 +1,188 @@
 {
-  "sling:resourceType": "wcm/dialogs/dialog",
-  "tabs": {
-    "sling:resourceType": "wcm/dialogs/components/tabs",
-    "generalTab": {
-      "sling:resourceType": "wcm/dialogs/components/tab",
-      "label": "General",
-      "dialogText": {
-        "sling:resourceType": "wcm/dialogs/components/richtext",
-        "name": "text",
-        "label": "Text",
-        "ws:disallowedContext": [
-          "edit:panel"
-        ]
-      },
-      "panelText": {
-        "sling:resourceType": "wcm/dialogs/components/richtext",
-        "name": "text",
-        "label": "Text",
-        "ws:disallowedContext": [
-          "edit:dialog"
-        ],
-        "configuration": "wcm/dialogs/components/richtext/configurations/compact"
-      },
-      "columns": {
-        "sling:resourceType": "wcm/dialogs/components/numberfield",
-        "name": "columns",
-        "min": 1,
-        "max": 100,
-        "label": "Columns",
-        "description": "The number of columns the cell should span"
-      },
-      "rows": {
-        "sling:resourceType": "wcm/dialogs/components/numberfield",
-        "name": "rows",
-        "min": 1,
-        "max": 100,
-        "label": "Rows",
-        "description": "The number of rows the cell should span"
-      },
-      "iconVariant": {
-        "sling:resourceType": "wcm/dialogs/components/select",
-        "name": "iconVariant",
-        "label": "Icon",
-        "none": {
-          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
-          "label": "No icon",
-          "value": "",
-          "selected": "true"
-        },
-        "iconOnTheLeft": {
-          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
-          "label": "Icon to the left",
-          "value": "icon-on-the-left"
-        },
-        "iconOnTheRight": {
-          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
-          "label": "Icon to the right",
-          "value": "icon-on-the-right"
-        }
-      }
-    },
-    "iconTabs": {
-      "sling:resourceType": "wcm/dialogs/components/tab",
-      "label": "Icon",
-      "embeddedIcon": {
-        "sling:resourceType": "wcm/dialogs/components/include",
-        "path": "/libs/kyanite/common/components/icon/dialog/tabs",
-        "namespace": "embeddedIcon",
-        "include": {
-          "sling:resourceSuperType": "/libs/kyanite/common/components/icon/dialog/tabs",
-          "generalTab": {
-            "typedIcon": {
-              "ws:display": {
-                "condition": {
-                  "sourceName": "embeddedIcon/selectOrType"
-                }
-              }
-            },
-            "iconFA": {
-              "selectableIcon": {
-                "include": {
-                  "sling:resourceSuperType": "kyanite/common/components/common/icon/icons/fontawesome",
-                  "name": "embeddedIcon/icon"
-                },
-                "ws:display": {
-                  "condition": {
-                    "sourceName": "embeddedIcon/selectOrType"
-                  }
-                }
-              },
-              "iconSize": {
-                "include": {
-                  "sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/fontawesome",
-                  "name": "embeddedIcon/iconSize"
-                }
-              },
-              "ws:display": {
-                "condition": {
-                  "sourceName": "embeddedIcon/iconLibType"
-                }
-              }
-            },
-            "iconMD": {
-              "selectableIcon": {
-                "include": {
-                  "sling:resourceSuperType": "kyanite/common/components/common/icon/icons/materialdesign",
-                  "name": "embeddedIcon/icon"
-                },
-                "ws:display": {
-                  "condition": {
-                    "sourceName": "embeddedIcon/selectOrType"
-                  }
-                }
-              },
-              "iconSize": {
-                "include": {
-                  "sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/materialdesign",
-                  "name": "embeddedIcon/iconSize"
-                }
-              },
-              "ws:display": {
-                "condition": {
-                  "sourceName": "embeddedIcon/iconLibType"
-                }
-              }
-            },
-            "iconSymbols": {
-              "selectableIcon": {
-                "include": {
-                  "sling:resourceSuperType": "kyanite/common/components/common/icon/icons/symbols",
-                  "name": "embeddedIcon/icon"
-                },
-                "ws:display": {
-                  "condition": {
-                    "sourceName": "embeddedIcon/selectOrType"
-                  }
-                }
-              },
-              "iconSize": {
-                "include": {
-                  "sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/symbols",
-                  "name": "embeddedIcon/iconSize"
-                }
-              },
-              "ws:display": {
-                "condition": {
-                  "sourceName": "embeddedIcon/iconLibType"
-                }
-              }
-            },
-            "textVariant": {
-              "include": {
-                "sling:resourceSuperType": "kyanite/common/components/common/textvariant",
-                "name": "embeddedIcon/textVariant"
-              }
-            }
-          },
-          "textTab": {
-            "textContainer": {
-              "ws:display": {
-                "condition": {
-                  "sourceName": "embeddedIcon/addText"
-                }
-              }
-            }
-          }
-        }
-      },
-      "ws:display": {
-        "condition": {
-          "sourceName": "iconVariant",
-          "values": [
-            "icon-on-the-left",
-            "icon-on-the-right"
-          ]
-        }
-      }
-    }
-  }
+	"sling:resourceType": "wcm/dialogs/dialog",
+	"cellType": {
+		"sling:resourceType": "wcm/dialogs/components/radio",
+		"name": "cellType",
+		"label": "Type of cell content",
+		"text": {
+			"sling:resourceType": "wcm/dialogs/components/radio/option",
+			"label": "Rich text editor",
+			"value": "text"
+		},
+		"icon": {
+			"sling:resourceType": "wcm/dialogs/components/radio/option",
+			"label": "Icon with text",
+			"value": "icon"
+		}
+	},
+	"textContainer": {
+		"sling:resourceType": "wcm/dialogs/components/container",
+		"dialogText": {
+			"sling:resourceType": "wcm/dialogs/components/richtext",
+			"name": "text",
+			"label": "Text",
+			"ws:disallowedContext": ["edit:panel"]
+		},
+		"panelText": {
+			"sling:resourceType": "wcm/dialogs/components/richtext",
+			"name": "text",
+			"label": "Text",
+			"ws:disallowedContext": ["edit:dialog"],
+			"configuration": "wcm/dialogs/components/richtext/configurations/compact"
+		},
+		"columns": {
+			"sling:resourceType": "wcm/dialogs/components/numberfield",
+			"name": "columns",
+			"min": 1,
+			"max": 100,
+			"label": "Columns",
+			"description": "The number of columns the cell should span"
+		},
+		"rows": {
+			"sling:resourceType": "wcm/dialogs/components/numberfield",
+			"name": "rows",
+			"min": 1,
+			"max": 100,
+			"label": "Rows",
+			"description": "The number of rows the cell should span"
+		},
+		"ws:display": {
+			"condition": {
+				"sourceName": "cellType",
+				"values": "text"
+			}
+		}
+	},
+	"iconContainer": {
+		"sling:resourceType": "wcm/dialogs/components/container",
+		"iconTabs": {
+			"sling:resourceType": "wcm/dialogs/components/tab",
+			"label": "Icon",
+			"embeddedIcon": {
+				"sling:resourceType": "wcm/dialogs/components/include",
+				"path": "/libs/kyanite/common/components/icon/dialog/tabs",
+				"namespace": "embeddedIcon",
+				"include": {
+					"sling:resourceSuperType": "/libs/kyanite/common/components/icon/dialog/tabs",
+					"generalTab": {
+						"typedIcon": {
+							"ws:display": {
+								"condition": {
+									"sourceName": "embeddedIcon/selectOrType"
+								}
+							}
+						},
+						"iconFA": {
+							"selectableIcon": {
+								"include": {
+									"sling:resourceSuperType": "kyanite/common/components/common/icon/icons/fontawesome",
+									"name": "embeddedIcon/icon"
+								},
+								"ws:display": {
+									"condition": {
+										"sourceName": "embeddedIcon/selectOrType"
+									}
+								}
+							},
+							"iconSize": {
+								"include": {
+									"sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/fontawesome",
+									"name": "embeddedIcon/iconSize"
+								}
+							},
+							"ws:display": {
+								"condition": {
+									"sourceName": "embeddedIcon/iconLibType"
+								}
+							}
+						},
+						"iconMD": {
+							"selectableIcon": {
+								"include": {
+									"sling:resourceSuperType": "kyanite/common/components/common/icon/icons/materialdesign",
+									"name": "embeddedIcon/icon"
+								},
+								"ws:display": {
+									"condition": {
+										"sourceName": "embeddedIcon/selectOrType"
+									}
+								}
+							},
+							"iconSize": {
+								"include": {
+									"sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/materialdesign",
+									"name": "embeddedIcon/iconSize"
+								}
+							},
+							"ws:display": {
+								"condition": {
+									"sourceName": "embeddedIcon/iconLibType"
+								}
+							}
+						},
+						"iconSymbols": {
+							"selectableIcon": {
+								"include": {
+									"sling:resourceSuperType": "kyanite/common/components/common/icon/icons/symbols",
+									"name": "embeddedIcon/icon"
+								},
+								"ws:display": {
+									"condition": {
+										"sourceName": "embeddedIcon/selectOrType"
+									}
+								}
+							},
+							"iconSize": {
+								"include": {
+									"sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/symbols",
+									"name": "embeddedIcon/iconSize"
+								}
+							},
+							"ws:display": {
+								"condition": {
+									"sourceName": "embeddedIcon/iconLibType"
+								}
+							}
+						},
+						"textVariant": {
+							"include": {
+								"sling:resourceSuperType": "kyanite/common/components/common/textvariant",
+								"name": "embeddedIcon/textVariant"
+							}
+						},
+						"iconVariant": {
+							"sling:resourceType": "wcm/dialogs/components/select",
+							"name": "iconVariant",
+							"label": "Position",
+							"iconOnTheLeft": {
+								"sling:resourceType": "wcm/dialogs/components/select/selectitem",
+								"label": "Icon to the left",
+								"value": "icon-on-the-left"
+							},
+							"iconOnTheRight": {
+								"sling:resourceType": "wcm/dialogs/components/select/selectitem",
+								"label": "Icon to the right",
+								"value": "icon-on-the-right"
+							}
+						}
+					},
+					"textTab": {
+						"textContainer": {
+							"ws:display": {
+								"condition": {
+									"sourceName": "embeddedIcon/addText"
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"ws:display": {
+			"condition": {
+				"sourceName": "cellType",
+				"values": "icon"
+			}
+		}
+	}
 }
-
-

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/dialog/.content.json
@@ -9,13 +9,17 @@
         "sling:resourceType": "wcm/dialogs/components/richtext",
         "name": "text",
         "label": "Text",
-        "ws:disallowedContext": ["edit:panel"]
+        "ws:disallowedContext": [
+          "edit:panel"
+        ]
       },
       "panelText": {
         "sling:resourceType": "wcm/dialogs/components/richtext",
         "name": "text",
         "label": "Text",
-        "ws:disallowedContext": ["edit:dialog"],
+        "ws:disallowedContext": [
+          "edit:dialog"
+        ],
         "configuration": "wcm/dialogs/components/richtext/configurations/compact"
       },
       "columns": {
@@ -33,7 +37,147 @@
         "max": 100,
         "label": "Rows",
         "description": "The number of rows the cell should span"
+      },
+      "iconVariant": {
+        "sling:resourceType": "wcm/dialogs/components/select",
+        "name": "iconVariant",
+        "label": "Icon",
+        "none": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "No icon",
+          "value": "",
+          "selected": "true"
+        },
+        "iconOnTheLeft": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Icon to the left",
+          "value": "icon-on-the-left"
+        },
+        "iconOnTheRight": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Icon to the right",
+          "value": "icon-on-the-right"
+        }
+      }
+    },
+    "iconTabs": {
+      "sling:resourceType": "wcm/dialogs/components/tab",
+      "label": "Icon",
+      "embeddedIcon": {
+        "sling:resourceType": "wcm/dialogs/components/include",
+        "path": "/libs/kyanite/common/components/icon/dialog/tabs",
+        "namespace": "embeddedIcon",
+        "include": {
+          "sling:resourceSuperType": "/libs/kyanite/common/components/icon/dialog/tabs",
+          "generalTab": {
+            "typedIcon": {
+              "ws:display": {
+                "condition": {
+                  "sourceName": "embeddedIcon/selectOrType"
+                }
+              }
+            },
+            "iconFA": {
+              "selectableIcon": {
+                "include": {
+                  "sling:resourceSuperType": "kyanite/common/components/common/icon/icons/fontawesome",
+                  "name": "embeddedIcon/icon"
+                },
+                "ws:display": {
+                  "condition": {
+                    "sourceName": "embeddedIcon/selectOrType"
+                  }
+                }
+              },
+              "iconSize": {
+                "include": {
+                  "sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/fontawesome",
+                  "name": "embeddedIcon/iconSize"
+                }
+              },
+              "ws:display": {
+                "condition": {
+                  "sourceName": "embeddedIcon/iconLibType"
+                }
+              }
+            },
+            "iconMD": {
+              "selectableIcon": {
+                "include": {
+                  "sling:resourceSuperType": "kyanite/common/components/common/icon/icons/materialdesign",
+                  "name": "embeddedIcon/icon"
+                },
+                "ws:display": {
+                  "condition": {
+                    "sourceName": "embeddedIcon/selectOrType"
+                  }
+                }
+              },
+              "iconSize": {
+                "include": {
+                  "sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/materialdesign",
+                  "name": "embeddedIcon/iconSize"
+                }
+              },
+              "ws:display": {
+                "condition": {
+                  "sourceName": "embeddedIcon/iconLibType"
+                }
+              }
+            },
+            "iconSymbols": {
+              "selectableIcon": {
+                "include": {
+                  "sling:resourceSuperType": "kyanite/common/components/common/icon/icons/symbols",
+                  "name": "embeddedIcon/icon"
+                },
+                "ws:display": {
+                  "condition": {
+                    "sourceName": "embeddedIcon/selectOrType"
+                  }
+                }
+              },
+              "iconSize": {
+                "include": {
+                  "sling:resourceSuperType": "kyanite/common/components/common/icon/iconsize/symbols",
+                  "name": "embeddedIcon/iconSize"
+                }
+              },
+              "ws:display": {
+                "condition": {
+                  "sourceName": "embeddedIcon/iconLibType"
+                }
+              }
+            },
+            "textVariant": {
+              "include": {
+                "sling:resourceSuperType": "kyanite/common/components/common/textvariant",
+                "name": "embeddedIcon/textVariant"
+              }
+            }
+          },
+          "textTab": {
+            "textContainer": {
+              "ws:display": {
+                "condition": {
+                  "sourceName": "embeddedIcon/addText"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ws:display": {
+        "condition": {
+          "sourceName": "iconVariant",
+          "values": [
+            "icon-on-the-left",
+            "icon-on-the-right"
+          ]
+        }
       }
     }
   }
 }
+
+

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
@@ -18,11 +18,10 @@
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.table.TableCellComponent">
   <td rowspan="${model.rowspan}" colspan="${model.colspan}">
-    <sly data-sly-set.leftIcon="${model.leftIcon}" data-sly-test="${leftIcon}">
-      <sly data-sly-resource="${leftIcon.path @ resourceType='kyanite/common/components/icon'}"/>
+    <sly data-sly-test="">
+      ${model.text @ context='unsafe'}
     </sly>
-    ${model.text @ context='unsafe'}
-    <sly data-sly-set.rightIcon="${model.rightIcon}" data-sly-test="${rightIcon}">
+    <sly data-sly-test="">
       <sly data-sly-resource="${rightIcon.path @ resourceType='kyanite/common/components/icon'}"/>
     </sly>
   </td>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
@@ -18,11 +18,11 @@
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.table.TableCellComponent">
   <td rowspan="${model.rowspan}" colspan="${model.colspan}">
-    <sly data-sly-test="">
+    <sly data-sly-test="${model.showText}">
       ${model.text @ context='unsafe'}
     </sly>
-    <sly data-sly-test="">
-      <sly data-sly-resource="${rightIcon.path @ resourceType='kyanite/common/components/icon'}"/>
-    </sly>
+    <div data-sly-test="${model.showIcon && model.icon}" class="${model.iconOnTheLeft ? 'on-the-left' : (model.iconOnTheRight ? 'on-the-right' : '')}">
+      <sly data-sly-resource="${model.icon.path @ resourceType='kyanite/common/components/icon', requestAttributes = wcmmode.disabledModeAttribute}"/>
+    </div>
   </td>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
@@ -18,6 +18,12 @@
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.table.TableCellComponent">
   <td rowspan="${model.rowspan}" colspan="${model.colspan}">
+    <sly data-sly-set.leftIcon="${model.leftIcon}" data-sly-test="${leftIcon}">
+      <sly data-sly-resource="${leftIcon.path @ resourceType='kyanite/common/components/icon'}"/>
+    </sly>
     ${model.text @ context='unsafe'}
+    <sly data-sly-set.rightIcon="${model.rightIcon}" data-sly-test="${rightIcon}">
+      <sly data-sly-resource="${rightIcon.path @ resourceType='kyanite/common/components/icon'}"/>
+    </sly>
   </td>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/table/tablecell/tablecell.html
@@ -17,12 +17,10 @@
 */-->
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.table.TableCellComponent">
-  <td rowspan="${model.rowspan}" colspan="${model.colspan}">
+  <td rowspan="${model.rowspan}" colspan="${model.colspan}" class="${model.showIcon && model.icon && model.iconOnTheRight ? 'icon-on-the-right' : ''}">
     <sly data-sly-test="${model.showText}">
       ${model.text @ context='unsafe'}
     </sly>
-    <div data-sly-test="${model.showIcon && model.icon}" class="${model.iconOnTheLeft ? 'on-the-left' : (model.iconOnTheRight ? 'on-the-right' : '')}">
-      <sly data-sly-resource="${model.icon.path @ resourceType='kyanite/common/components/icon', requestAttributes = wcmmode.disabledModeAttribute}"/>
-    </div>
+    <sly data-sly-test="${model.showIcon && model.icon}" data-sly-resource="${model.icon.path @ resourceType='kyanite/common/components/icon', requestAttributes = wcmmode.disabledModeAttribute}"/>
   </td>
 </sly>

--- a/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableCellComponentTest.java
+++ b/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableCellComponentTest.java
@@ -46,11 +46,12 @@ public class TableCellComponentTest {
     final TableCellComponent model = createModel("tablebody/tablerow1/default");
 
     assertThat(model).isNotNull();
+    assertThat(model.isShowText()).isTrue();
     assertThat(model.getText()).isEqualTo("Content");
     assertThat(model.getRowspan()).isEqualTo(1);
     assertThat(model.getColspan()).isEqualTo(12);
-    assertThat(model.getLeftIcon()).isEmpty();
-    assertThat(model.getRightIcon()).isEmpty();
+    assertThat(model.isShowIcon()).isFalse();
+    assertThat(model.getIcon()).isEmpty();
   }
 
   @Test
@@ -58,27 +59,37 @@ public class TableCellComponentTest {
     final TableCellComponent model = createModel("tablebody/tablerow2/complex");
 
     assertThat(model).isNotNull();
+    assertThat(model.isShowText()).isTrue();
     assertThat(model.getText()).isEqualTo("Table cell text");
     assertThat(model.getRowspan()).isEqualTo(2);
     assertThat(model.getColspan()).isEqualTo(3);
+    assertThat(model.isShowIcon()).isFalse();
   }
 
   @Test
-  void shouldResolveLeftIconWhenEnabled() {
-    final TableCellComponent model = createModel("tablebody/tablerow3/withLeftIcon");
+  void shouldResolveLeftOrientedIconWhenEnabled() {
+    final TableCellComponent model = createModel("tablebody/tablerow3/withLeftOrientedIcon");
 
     assertThat(model).isNotNull();
-    assertThat(model.getLeftIcon()).isNotEmpty();
-    assertThat(model.getRightIcon()).isEmpty();
+    assertThat(model.isShowText()).isFalse();
+
+    assertThat(model.isShowIcon()).isTrue();
+    assertThat(model.getIcon()).isNotEmpty();
+    assertThat(model.isIconOnTheLeft()).isTrue();
+    assertThat(model.isIconOnTheRight()).isFalse();
   }
 
   @Test
   void shouldResolveRightIconWhenEnabled() {
-    final TableCellComponent model = createModel("tablebody/tablerow3/withRightIcon");
+    final TableCellComponent model = createModel("tablebody/tablerow3/withRightOrientedIcon");
 
     assertThat(model).isNotNull();
-    assertThat(model.getLeftIcon()).isEmpty();
-    assertThat(model.getRightIcon()).isNotEmpty();
+    assertThat(model.isShowText()).isFalse();
+
+    assertThat(model.isShowIcon()).isTrue();
+    assertThat(model.getIcon()).isNotEmpty();
+    assertThat(model.isIconOnTheLeft()).isFalse();
+    assertThat(model.isIconOnTheRight()).isTrue();
   }
 
   private TableCellComponent createModel(final String componentResourceSubPath) {

--- a/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableCellComponentTest.java
+++ b/applications/common/backend/src/test/java/pl/ds/kyanite/common/components/models/table/TableCellComponentTest.java
@@ -42,21 +42,47 @@ public class TableCellComponentTest {
   }
 
   @Test
-  void defaultTableCellComponentModelTest() {
-    TableCellComponent model = context.resourceResolver().getResource(PATH + "/tablebody/tablerow1/default")
-        .adaptTo(TableCellComponent.class);
+  void shouldUseDefaultsWhenNoConfigurationSet() {
+    final TableCellComponent model = createModel("tablebody/tablerow1/default");
+
     assertThat(model).isNotNull();
     assertThat(model.getText()).isEqualTo("Content");
     assertThat(model.getRowspan()).isEqualTo(1);
     assertThat(model.getColspan()).isEqualTo(12);
+    assertThat(model.getLeftIcon()).isEmpty();
+    assertThat(model.getRightIcon()).isEmpty();
   }
 
   @Test
-  void tableCellComponentModelTest() {
-    TableCellComponent model = context.resourceResolver().getResource(PATH + "/tablebody/tablerow2/complex")
-        .adaptTo(TableCellComponent.class);
+  void shouldUseAuthorProvidedConfigurationWhenSet() {
+    final TableCellComponent model = createModel("tablebody/tablerow2/complex");
+
+    assertThat(model).isNotNull();
     assertThat(model.getText()).isEqualTo("Table cell text");
     assertThat(model.getRowspan()).isEqualTo(2);
     assertThat(model.getColspan()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldResolveLeftIconWhenEnabled() {
+    final TableCellComponent model = createModel("tablebody/tablerow3/withLeftIcon");
+
+    assertThat(model).isNotNull();
+    assertThat(model.getLeftIcon()).isNotEmpty();
+    assertThat(model.getRightIcon()).isEmpty();
+  }
+
+  @Test
+  void shouldResolveRightIconWhenEnabled() {
+    final TableCellComponent model = createModel("tablebody/tablerow3/withRightIcon");
+
+    assertThat(model).isNotNull();
+    assertThat(model.getLeftIcon()).isEmpty();
+    assertThat(model.getRightIcon()).isNotEmpty();
+  }
+
+  private TableCellComponent createModel(final String componentResourceSubPath) {
+    return context.resourceResolver().getResource(PATH + "/" + componentResourceSubPath)
+        .adaptTo(TableCellComponent.class);
   }
 }

--- a/applications/common/backend/src/test/resources/tablecell.json
+++ b/applications/common/backend/src/test/resources/tablecell.json
@@ -14,6 +14,46 @@
         "rows": 2,
         "columns": 3
       }
+    },
+    "tablerow3": {
+      "withLeftIcon": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kyanite/common/components/table/tablecell",
+        "textVariant": "",
+        "iconVariant": "icon-on-the-left",
+        "text": "\u003Cp\u003ETable cell content\u003C/p\u003E",
+        "embeddedIcon": {
+          "jcr:primaryType": "nt:unstructured",
+          "addText": "true",
+          "iconSize": "mdi-36px",
+          "textVariant": "has-text-success",
+          "iconLibType": "mdi",
+          "icon": "mdi-home-outline",
+          "label": "Text added to icon",
+          "elementType": "div",
+          "colorOnText": "true",
+          "selectOrType": "select"
+        }
+      },
+      "withRightIcon": {
+        "jcr:primaryType": "nt:unstructured",
+        "sling:resourceType": "kyanite/common/components/table/tablecell",
+        "textVariant": "",
+        "iconVariant": "icon-on-the-right",
+        "text": "\u003Cp\u003ETable cell content\u003C/p\u003E",
+        "embeddedIcon": {
+          "jcr:primaryType": "nt:unstructured",
+          "addText": "true",
+          "iconSize": "mdi-36px",
+          "textVariant": "has-text-success",
+          "iconLibType": "mdi",
+          "icon": "mdi-home-outline",
+          "label": "Text added to icon",
+          "elementType": "div",
+          "colorOnText": "true",
+          "selectOrType": "select"
+        }
+      }
     }
   }
 }

--- a/applications/common/backend/src/test/resources/tablecell.json
+++ b/applications/common/backend/src/test/resources/tablecell.json
@@ -10,22 +10,23 @@
       "complex": {
         "jcr:primaryType": "nt:unstructured",
         "sling:resourceType": "kyanite/common/components/table/tablecell",
+        "cellType": "text",
         "text": "Table cell text",
         "rows": 2,
         "columns": 3
       }
     },
     "tablerow3": {
-      "withLeftIcon": {
+      "withLeftOrientedIcon": {
         "jcr:primaryType": "nt:unstructured",
         "sling:resourceType": "kyanite/common/components/table/tablecell",
-        "textVariant": "",
-        "iconVariant": "icon-on-the-left",
+        "cellType": "icon",
         "text": "\u003Cp\u003ETable cell content\u003C/p\u003E",
         "embeddedIcon": {
           "jcr:primaryType": "nt:unstructured",
           "addText": "true",
           "iconSize": "mdi-36px",
+          "iconVariant": "icon-on-the-left",
           "textVariant": "has-text-success",
           "iconLibType": "mdi",
           "icon": "mdi-home-outline",
@@ -35,16 +36,17 @@
           "selectOrType": "select"
         }
       },
-      "withRightIcon": {
+      "withRightOrientedIcon": {
         "jcr:primaryType": "nt:unstructured",
         "sling:resourceType": "kyanite/common/components/table/tablecell",
         "textVariant": "",
-        "iconVariant": "icon-on-the-right",
+        "cellType": "icon",
         "text": "\u003Cp\u003ETable cell content\u003C/p\u003E",
         "embeddedIcon": {
           "jcr:primaryType": "nt:unstructured",
           "addText": "true",
           "iconSize": "mdi-36px",
+          "iconVariant": "icon-on-the-right",
           "textVariant": "has-text-success",
           "iconLibType": "mdi",
           "icon": "mdi-home-outline",

--- a/applications/common/frontend/src/components/Table/Table.scss
+++ b/applications/common/frontend/src/components/Table/Table.scss
@@ -61,6 +61,16 @@
           }
         }
       }
+      td {
+        &.icon-on-the-right {
+          .icon-text {
+            flex-direction: row-reverse;
+          }
+        }
+        .icon-text {
+          gap: 1rem;
+        }
+      }
     }
     &.is-first-column-locked {
       .table {


### PR DESCRIPTION
## Description
This MR introduces the following changes:
* Enhance *Table cell* component's configuration dialog to support either rendering rich text (as it's currently supported) or an icon (optionally with some text added)
* Available icon properties are the same as supported for the *Icon* component


## Motivation and Context
Enable content authors to configure icons in tables for a more pleasant visual experiences.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
