### PR TITLE
WSIO-1192 manage blog heading levels

### DIFF
--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/bloglist.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/bloglist.html
@@ -26,7 +26,9 @@
         </div>
         <div class="content">
           <div class="content-info">
-            <h6 class="title is-6" data-sly-test.title="${item.blogArticleHeader.title}">${title}</h6>
+            <h6 class="title is-6"
+                data-sly-element="${properties.element}"
+                data-sly-test.title="${item.blogArticleHeader.title}">${title}</h6>
             <div class="content-info-details">
               <p>
                 <sly data-sly-test.author="${item.authorInfo}">

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/dialog/.content.json
@@ -27,6 +27,7 @@
         "include": {
           "sling:resourceSuperType": "/libs/kyanite/blogs/components/common/dialog/authorinfo",
           "authorInfoSource": {
+            "description": "Define the author info source to filter the list to their articles",
             "ownProperties": {
               "sling:hideResource": true
             }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/dialog/.content.json
@@ -11,6 +11,17 @@
         "name": "link",
         "label": "Path to the blog article pages"
       },
+      "element": {
+        "sling:resourceType": "wcm/dialogs/components/include",
+        "include": {
+          "sling:resourceSuperType": "/libs/kyanite/common/components/common/headinglevel",
+          "name": "element",
+          "description": "Heading Level for articles' titles",
+          "h1": {
+            "sling:hideResource": "true"
+          }
+        }
+      },
       "authorInfo": {
         "sling:resourceType": "wcm/dialogs/components/include",
         "include": {

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/dialog/.content.json
@@ -11,6 +11,17 @@
         "name": "link",
         "label": "Path to the blog article page"
       },
+      "element": {
+        "sling:resourceType": "wcm/dialogs/components/include",
+        "include": {
+          "sling:resourceSuperType": "/libs/kyanite/common/components/common/headinglevel",
+          "name": "element",
+          "description": "Heading Level for article title",
+          "h1": {
+            "sling:hideResource": "true"
+          }
+        }
+      },
       "isReversed": {
         "sling:resourceType": "wcm/dialogs/components/checkbox",
         "name": "isReversed",

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/featuredblogarticle.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/featuredblogarticle.html
@@ -36,7 +36,9 @@
                   </span>
                 </sly>
               </div>
-              <h4 class="title is-4" data-sly-test.title="${article.title}">${title}</h4>
+              <h4 class="title is-4"
+                  data-sly-element="${properties.element}"
+                  data-sly-test.title="${article.title}">${title}</h4>
               <p data-sly-test.description="${article.description}" class="article-description">
                 ${description @ context='html'}
               </p>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/title.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/title/title.html
@@ -18,9 +18,9 @@
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.TitleComponent">
   <sly data-sly-test="${model.addEyebrow}">
-    <h6 class="has-text-primary is-1 eyebrow">
+    <span class="has-text-primary is-1 eyebrow">
       ${model.eyebrowText}
-    </h6>
+    </span>
   </sly>
   <h1 id="${model.anchorId}" style="text-align: ${model.titleAlign @ context='styleToken'};" data-sly-element="${model.element}" class="${model.titleClasses @ join=' '} ${model.addAnimatedEndings ? 'is-relative' : ''}">
     ${model.textAsOneLine @ context='html'}


### PR DESCRIPTION
- the element of the eyebrow in Title component was changed from H6 to span
- in BlogList and FeaturedArticle, a headingLevel dialog property was included to manage article titles' element
- a meaningful description for authorInfoSource property was provided for BlogList

Default behaviour didn't change: 

- BlogList article's title is h6
- FeaturedArticle article's title is h4

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://teamds.atlassian.net/browse/WSIO-1192

## Screenshots (if appropriate)
<img width="364" alt="image" src="https://github.com/websight-io/kyanite/assets/13979207/8b25299a-e785-499e-82c4-b151b8db3fd3">


## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
