### PR TITLE
KYAN-1258 (wsio-1258) delete fixed font size on resize

### DIFF
--- a/applications/common/frontend/src/components/Title/animatedEndings.class.ts
+++ b/applications/common/frontend/src/components/Title/animatedEndings.class.ts
@@ -85,6 +85,7 @@ export class AnimatedEndings {
 
     if (this.noTitleWrapping) {
       window.onresize = () => {
+        this.titleElement.style.removeProperty('font-size');
         AnimatedEndings.setFontSize(this.titleElement);
       };
     } else {
@@ -107,7 +108,7 @@ export class AnimatedEndings {
   }
 
   static setFontSize(titleEl: HTMLElement) {
-    if (window.matchMedia(`(max-width: ${breakpoints.md}px)`).matches) {
+    if (window.matchMedia(`(max-width: ${breakpoints.xxl}px)`).matches) {
       const initialSize = Number(
         window.getComputedStyle(titleEl).fontSize.split('px')[0]
       );

--- a/applications/common/frontend/src/helpers/breakpoints.ts
+++ b/applications/common/frontend/src/helpers/breakpoints.ts
@@ -18,4 +18,6 @@ export const breakpoints = {
   sm: 0,
   md: 768,
   lg: 1024,
+  xl: 1216,
+  xxl: 1408
 };


### PR DESCRIPTION
Fix for an animated title - when resizing window back to bigger size, font size resets - tests purposes mainly, but in some cases also UX improvement

Also animated title wrapping will be working now until 1408px (font enlargement issue)

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
