### PR TITLE
Fix/KYAN-291 image previews

### DIFF
--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/templates/blogarticlepage/initial/.content.json
@@ -115,7 +115,6 @@
             },
             "column4": {
               "sling:resourceType": "kyanite/common/components/columns/column",
-              "customClass" : "previewImageContainer",
               "desktopColumnStyle": {
                 "jcr:primaryType": "nt:unstructured",
                 "size": "eight",

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/PageBodyComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/PageBodyComponent.java
@@ -57,6 +57,10 @@ public class PageBodyComponent {
   @ValueMapValue
   private boolean addCaptcha;
 
+  @Getter
+  @ValueMapValue
+  private boolean createPreviewImagesCarousel;
+
   private String spaceName;
 
   @Getter

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/image/template.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/image/template.html
@@ -45,7 +45,10 @@
       <source media="(max-width:1023px)" srcset="${model.tabletAssetReference @ context='uri'}"/>
     </sly>
 
-    <img class="${model.isRounded ? 'is-rounded' : ''}${model.showLightbox ? ' image--lightbox' : ''}" width="${model.width}" height="${model.height}"  src="${model.assetReference}" alt="${model.alt}" data-lightbox-asset="${model.highResolutionAssetSrc}" loading="lazy">
+    <img class="${model.isRounded ? 'is-rounded' : ''}${model.showLightbox ? ' image--lightbox' : ''}"
+         width="${model.width}" height="${model.height}"
+         src="${model.assetReference}" alt="${model.alt}" loading="lazy"
+         data-sly-attribute.data-lightbox-asset="${model.showLightbox ? model.highResolutionAssetSrc : ''}">
   </picture>
 </template>
 

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/body.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/body.html
@@ -20,8 +20,11 @@
   <sly data-sly-set.templateMarker="template-${extra.templateName}"></sly>
   <sly data-sly-set.pageMarker="page-${extra.pageName}"></sly>
   <sly data-sly-set.noNavbarPadding="${extra.noNavbarPadding ? 'no-navbar-padding' : ''}"></sly>
+  <sly data-sly-set.previewImageCarouselMarker="${extra.createPreviewImagesCarousel ? 'previewImageContainer' : ''}"></sly>
 
-  <body class="${properties.defaultTemplateCSS} ${templateMarker} ${pageMarker} ${properties.background} ${noNavbarPadding}" data-cookie-config="${extra.cookieData}">
+  <body class="${properties.defaultTemplateCSS} ${properties.background}
+               ${templateMarker} ${pageMarker} ${noNavbarPadding} ${previewImageCarouselMarker}"
+        data-cookie-config="${extra.cookieData}">
   <!-- Google Tag Manager (noscript) -->
   <noscript data-sly-test="${extra.hasAnalyticsUrl}">
     <iframe src="https://www.googletagmanager.com/ns.html?id=${extra.googleAnalyticsTrackingId @ context='text'}" height="0" width="0" style="display:none;visibility:hidden"></iframe>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/dialog/.content.json
@@ -31,6 +31,12 @@
         "sling:resourceType": "wcm/dialogs/components/checkbox",
         "label": "Add reCAPTCHA",
         "name": "addCaptcha"
+      },
+      "createPreviewImagesCarousel": {
+        "sling:resourceType": "wcm/dialogs/components/checkbox",
+        "label": "Show images preview in carousel",
+        "description": "When checked, all the images with 'Display in lightbox' property will be shown in a single carousel",
+        "name": "createPreviewImagesCarousel"
       }
     },
     "metadata": {

--- a/applications/common/frontend/src/components/Image/Image.scss
+++ b/applications/common/frontend/src/components/Image/Image.scss
@@ -28,7 +28,7 @@ $color-shadow-end: rgba(#605e78, 0.07);
 
   &.has-shadow {
     box-shadow: 0 3.1015px 19.2293px 4.3421px $color-shadow-start,
-      0 0.6203px 2.4812px $color-shadow-end;
+    0 0.6203px 2.4812px $color-shadow-end;
   }
 
   > svg {
@@ -41,22 +41,16 @@ $color-shadow-end: rgba(#605e78, 0.07);
 }
 
 .viewer-backdrop {
-  background-color: rgba(0,0,0,.9);
+  background-color: rgba(0, 0, 0, .9);
 }
 
 .viewer-open > .navbar {
   padding-right: 15px;
 }
 
-.previewImageContainer {
+.image:has(img.image--lightbox) {
 
-  .image {
-    position: relative;
-  }
-
-  .previewCarouselImage {
-    cursor: pointer;
-  }
+  position: relative;
 
   .previewIcon {
     position: absolute;

--- a/applications/common/frontend/src/components/Image/image.ts
+++ b/applications/common/frontend/src/components/Image/image.ts
@@ -16,8 +16,14 @@
 
 import Viewer from "viewerjs";
 
-// We may extend this array later with additional pages that need to have an image preview carousel
-const imageCarouselTemplates = ["template-blogarticlepage"];
+const IMAGES_PREVIEW_ROOT_CLASS = "previewImageContainer";
+const IMAGES_PREVIEW_ROOT_SELECTOR = `.${IMAGES_PREVIEW_ROOT_CLASS}`;
+const IMAGE_PREVIEW_IMAGE_SELECTOR = "img.image--lightbox";
+const IMAGE_PREVIEW_CONTAINER_SELECTOR = `.image:has(${IMAGE_PREVIEW_IMAGE_SELECTOR})`;
+
+const shouldCreateCarousel = () => {
+  return document.body.classList.contains(IMAGES_PREVIEW_ROOT_CLASS);
+}
 
 const onViewed = (event, viewer) => {
   const heightFillFactor = 0.8;
@@ -107,32 +113,36 @@ const createPreviewCarousel = (imageContainer) => {
   });
 };
 
-if (imageCarouselTemplates.some(className => document.body.classList.contains(className))) {
-  const imageContainer = document.querySelector<HTMLElement>(
-    '.previewImageContainer'
-  );
-  const previewCarouselImages = document.querySelectorAll<HTMLElement>(
-    '.previewImageContainer .image'
-  );
+window.addEventListener(window.KYANITE_ON_LOAD, () => {
+  if (shouldCreateCarousel()) {
 
-  previewCarouselImages.forEach((imageContainer) => {
-    const imageElement = imageContainer.querySelector('img');
-    imageElement.classList.add('previewCarouselImage');
-    imageContainer.innerHTML +=
-      '<svg class="previewIcon" width="30" height="30" viewBox="9 9 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
-      '  <rect width="45" height="45" rx="24" x="9" y="9" fill="#1B1C20"/>\n' +
-      '  <path fill-rule="evenodd" clip-rule="evenodd" d="M32 24H40V32H42V22H32V24ZM24 32H22V42H32V40H24V32Z" fill="#ECF5FF"/>\n' +
-      '</svg>';
-  });
+    const rootPreviewContainer = document.querySelector<HTMLElement>(
+        IMAGES_PREVIEW_ROOT_SELECTOR
+    );
+    if (!rootPreviewContainer) return;
 
-  if (imageContainer !== null) {
-    createPreviewCarousel(imageContainer);
+    const previewImageContainers = document.querySelectorAll<HTMLElement>(
+        `${IMAGES_PREVIEW_ROOT_SELECTOR} ${IMAGE_PREVIEW_CONTAINER_SELECTOR}`
+    );
+    if (previewImageContainers.length == 0) return;
+
+    previewImageContainers.forEach((imageContainer) => {
+      const imageElement = imageContainer.querySelector(IMAGE_PREVIEW_IMAGE_SELECTOR);
+      imageElement.classList.add('previewCarouselImage');
+      imageContainer.innerHTML +=
+          '<svg class="previewIcon" width="30" height="30" viewBox="9 9 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">\n' +
+          '  <rect width="45" height="45" rx="24" x="9" y="9" fill="#1B1C20"/>\n' +
+          '  <path fill-rule="evenodd" clip-rule="evenodd" d="M32 24H40V32H42V22H32V24ZM24 32H22V42H32V40H24V32Z" fill="#ECF5FF"/>\n' +
+          '</svg>';
+    });
+
+    createPreviewCarousel(rootPreviewContainer);
+  } else {
+    const imagesWithLightbox = document.querySelectorAll<HTMLImageElement>(
+        IMAGE_PREVIEW_IMAGE_SELECTOR
+    );
+    if (imagesWithLightbox.length > 0) {
+      createSeparatePreviews(imagesWithLightbox);
+    }
   }
-} else {
-  const imagesWithLightbox = document.querySelectorAll<HTMLImageElement>(
-      ".image--lightbox"
-  );
-  if (imagesWithLightbox !== null) {
-    createSeparatePreviews(imagesWithLightbox);
-  }
-}
+});

--- a/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-article-author-bio/.content.xml
+++ b/tests/content/src/main/content/jcr_root/content/kyanite-visual-tests/pages/blog-article-author-bio/.content.xml
@@ -155,8 +155,7 @@
                         </column3>
                         <column4
                             jcr:primaryType="nt:unstructured"
-                            sling:resourceType="kyanite/common/components/columns/column"
-                            customClass="previewImageContainer">
+                            sling:resourceType="kyanite/common/components/columns/column">
                             <desktopColumnStyle
                                 jcr:primaryType="nt:unstructured"
                                 isNormalColumn="true"


### PR DESCRIPTION
Kyanite page property "Show image preview in carousel" added. It adds a class to the <body> and makes images with 'Display in lightbox' property be previewed in a carousel. When unchecked, lightbox-images are previewed separately.
Also preview icon now shows for images previewable separately, and the hover cursor is the same for carousel/separately previewed images.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
https://teamds.atlassian.net/browse/KYAN-291

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
