### PR TITLE
KYAN-298 Add cookie option to YouTube videos and set nocookie as default

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
@@ -88,6 +88,10 @@ public class VideoComponent {
   private String youtubeLink;
 
   @ValueMapValue
+  @Default(booleanValues = false)
+  private boolean enableCookies;
+
+  @ValueMapValue
   @Default(values = StringUtils.EMPTY)
   private String vimeoLink;
 
@@ -120,7 +124,7 @@ public class VideoComponent {
     }
 
     switch (this.source) {
-      case ("youtube") -> this.src = VideoLinkParser.getYouTubeLink(youtubeLink);
+      case ("youtube") -> this.src = VideoLinkParser.getYouTubeLink(youtubeLink, enableCookies);
       case ("vimeo") -> this.src = VideoLinkParser.getVimeoLink(vimeoLink);
       default -> this.src = StringUtils.EMPTY;
     }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/VideoLinkParser.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/VideoLinkParser.java
@@ -25,6 +25,9 @@ public class VideoLinkParser {
       "(?:embed|vi?)/([^/?]*)", "(?:user/[A-Za-z0-9]*#[a-z]/[a-z]/[a-z0-9]*/*)/([^&]*)",
       "^([A-Za-z0-9\\-]*)"};
   private static final String YOUTUBE_PLAYER_URL_PREFIX = "https://www.youtube.com/embed/";
+
+  private static final String YOUTUBE_PLAYER_URL_NOCOOKIE_PREFIX = "https://www.youtube-nocookie.com/embed/";
+
   private static final String[] VIMEO_VIDEO_ID_REGEX = {
       "(?:video|channels|groups/name/videos)/([^/?]*)",
       "^([A-Za-z0-9\\-]*)"};
@@ -36,12 +39,15 @@ public class VideoLinkParser {
       + "(www.)?(m.)?((vimeo.com)|(player.vimeo.com))/";
   private static final String VIMEO_PLAYER_URL_PREFIX = "https://player.vimeo.com/video/";
 
-  public static String getYouTubeLink(String link) {
+  public static String getYouTubeLink(String link, boolean enableCookies) {
     if (isYouTubeFullUrl(link)) {
       link = extractVideoIdFromUrl(link, YOUTUBE_VIDEO_ID_REGEX, YOUTUBE_URL_REGEX);
     }
+    if (enableCookies) {
+      return YOUTUBE_PLAYER_URL_PREFIX + link;
+    }
 
-    return YOUTUBE_PLAYER_URL_PREFIX + link;
+    return YOUTUBE_PLAYER_URL_NOCOOKIE_PREFIX + link;
   }
 
   public static String getVimeoLink(String link) {

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
@@ -51,6 +51,12 @@
           "name": "youtubeLink",
           "label": "Youtube link"
         },
+        "enableCookies": {
+          "sling:resourceType": "wcm/dialogs/components/toggle",
+          "description": "By default all links will be generated using the youtube-nocookie.com domain, but if this property is set to true, it will generated with simply youtube.com",
+          "name": "enableCookies",
+          "label": "Enable cookies"
+        },
         "ws:display": {
           "condition": {
             "sourceName": "source",


### PR DESCRIPTION
Add cookie option to YouTube videos and set nocookie as default

## Description
By default our VideoLinkParser set the domain of every YouTube link to `youtube.com`. From now on (as per the marketing team's decision) we will set the domain to `youtube-nocookie.com` by default, and provide an option on the dialog for the authors to change this to the old version if needed.

## Motivation and Context
YouTube videos have their own statistics, so by default no additional tracking is needed through cookies.


## Upgrade notes (if appropriate)
A new property is added, but no migration script is needed, as its default value is false.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
