### PR TITLE
KYAN-299 Improve video component with YT IFrame API

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
@@ -88,6 +88,7 @@ public class VideoComponent {
   private String youtubeLink;
 
   @ValueMapValue
+  @Getter
   @Default(booleanValues = false)
   private boolean enableCookies;
 
@@ -97,6 +98,9 @@ public class VideoComponent {
 
   @Getter
   private String src;
+
+  @Getter
+  private String youtubeIframeId;
 
   @SlingObject
   private Resource resource;
@@ -124,7 +128,14 @@ public class VideoComponent {
     }
 
     switch (this.source) {
-      case ("youtube") -> this.src = VideoLinkParser.getYouTubeLink(youtubeLink, enableCookies);
+      case ("youtube") -> {
+        this.src = VideoLinkParser.getYouTubeLink(youtubeLink, enableCookies);
+        this.youtubeIframeId = VideoLinkParser.getYouTubeId(youtubeLink) != null
+            ? "player-" + VideoLinkParser.getYouTubeId(youtubeLink) : "player";
+        if (enableCookies) {
+          this.parameters.put("enablejsapi", true);
+        }
+      }
       case ("vimeo") -> this.src = VideoLinkParser.getVimeoLink(vimeoLink);
       default -> this.src = StringUtils.EMPTY;
     }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
 import lombok.Getter;
@@ -87,10 +88,13 @@ public class VideoComponent {
   @Default(values = StringUtils.EMPTY)
   private String youtubeLink;
 
+  @Getter
+  private String youtubeIframeId;
+
   @ValueMapValue
   @Getter
   @Default(booleanValues = false)
-  private boolean enableCookies;
+  private boolean trackInteractions;
 
   @ValueMapValue
   @Default(values = StringUtils.EMPTY)
@@ -98,9 +102,6 @@ public class VideoComponent {
 
   @Getter
   private String src;
-
-  @Getter
-  private String youtubeIframeId;
 
   @SlingObject
   private Resource resource;
@@ -129,10 +130,10 @@ public class VideoComponent {
 
     switch (this.source) {
       case ("youtube") -> {
-        this.src = VideoLinkParser.getYouTubeLink(youtubeLink, enableCookies);
-        this.youtubeIframeId = VideoLinkParser.getYouTubeId(youtubeLink) != null
-            ? "player-" + VideoLinkParser.getYouTubeId(youtubeLink) : "player";
-        if (enableCookies) {
+        this.src = VideoLinkParser.getYouTubeLink(youtubeLink, trackInteractions);
+        this.youtubeIframeId = Optional.ofNullable(VideoLinkParser.getYouTubeId(youtubeLink))
+            .map(id -> "player-" + id).orElse("player");
+        if (trackInteractions) {
           this.parameters.put("enablejsapi", true);
         }
       }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/VideoLinkParser.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/utils/VideoLinkParser.java
@@ -50,6 +50,10 @@ public class VideoLinkParser {
     return YOUTUBE_PLAYER_URL_NOCOOKIE_PREFIX + link;
   }
 
+  public static String getYouTubeId(String youtubeLink) {
+    return extractVideoIdFromUrl(youtubeLink, YOUTUBE_VIDEO_ID_REGEX, YOUTUBE_URL_REGEX);
+  }
+
   public static String getVimeoLink(String link) {
     if (isVimeoFullUrl(link)) {
       link = extractVideoIdFromUrl(link, VIMEO_VIDEO_ID_REGEX, VIMEO_URL_REGEX);

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
@@ -51,10 +51,10 @@
           "name": "youtubeLink",
           "label": "Youtube link"
         },
-        "enableCookies": {
+        "trackInteractions": {
           "sling:resourceType": "wcm/dialogs/components/toggle",
           "description": "Turning on this property will enable using the YouTube IFrame API to track user interactions.",
-          "name": "enableCookies",
+          "name": "trackInteractions",
           "label": "Track interactions"
         },
         "ws:display": {

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
@@ -53,9 +53,9 @@
         },
         "enableCookies": {
           "sling:resourceType": "wcm/dialogs/components/toggle",
-          "description": "By default all links will be generated using the youtube-nocookie.com domain, but if this property is set to true, it will generated with simply youtube.com",
+          "description": "Turning on this property will enable using the YouTube IFrame API to track user interactions.",
           "name": "enableCookies",
-          "label": "Enable cookies"
+          "label": "Track interactions"
         },
         "ws:display": {
           "condition": {

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/video.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/video.html
@@ -35,14 +35,13 @@
         <img class="iframe-thumbnail" src="${model.thumbnail}" alt="Thumbnail image">
       </sly>
       <sly data-sly-test.link="${[model.src,model.shareLinkParameters] @ join = '?'}"></sly>
-      <iframe id="player"
+      <iframe id="${model.youtubeIframeId}"
+              class="${model.enableCookies ? 'player-with-cookies' : 'player'}"
               width="${model.width || '100%' @ context='scriptString'}"
               height="${model.height || 390 @ context='scriptString'}"
               src="${link}"
               title="Video player"
-              frameborder="0"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
       ></iframe>
     </sly>
   </div>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/video.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/video.html
@@ -36,7 +36,7 @@
       </sly>
       <sly data-sly-test.link="${[model.src,model.shareLinkParameters] @ join = '?'}"></sly>
       <iframe id="${model.youtubeIframeId}"
-              class="${model.enableCookies ? 'player-with-cookies' : 'player'}"
+              class="${model.trackInteractions ? 'player-with-cookies' : 'player'}"
               width="${model.width || '100%' @ context='scriptString'}"
               height="${model.height || 390 @ context='scriptString'}"
               src="${link}"

--- a/applications/common/frontend/.eslintrc.js
+++ b/applications/common/frontend/.eslintrc.js
@@ -40,7 +40,8 @@ module.exports = {
     "**/*/navbar.js",
     "**/*/notification.js",
     "**/*/panelTabs.js",
-    "**/*/switchTab.js"],
+    "**/*/switchTab.js",
+    "**/*/video.js"],
   rules: {
     '@typescript-eslint/no-misused-promises': [
       'error',

--- a/applications/common/frontend/src/components/Video/Video.scss
+++ b/applications/common/frontend/src/components/Video/Video.scss
@@ -1,0 +1,21 @@
+/*!
+ * <!--
+ *     Copyright (C) 2025 Dynamic Solutions
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * -->
+ */
+
+iframe.player, iframe.player-with-cookies {
+  border: 0;
+}

--- a/applications/common/frontend/src/components/Video/_index.scss
+++ b/applications/common/frontend/src/components/Video/_index.scss
@@ -1,0 +1,19 @@
+/*!
+ * <!--
+ *     Copyright (C) 2025 Dynamic Solutions
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * -->
+ */
+
+@forward 'Video';

--- a/applications/common/frontend/src/components/Video/video.js
+++ b/applications/common/frontend/src/components/Video/video.js
@@ -1,0 +1,32 @@
+/*!
+ * <!--
+ *     Copyright (C) 2025 Dynamic Solutions
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ * -->
+ */
+
+document.addEventListener("DOMContentLoaded", (event) => {
+  if (document.querySelector('.player-with-cookies')) {
+    let tag = document.createElement('script');
+    tag.id = 'yt-iframe-api';
+    tag.src = 'https://www.youtube.com/iframe_api';
+    document.head.appendChild(tag);
+
+    window.onYouTubeIframeAPIReady = function() {
+      document.querySelectorAll(".player-with-cookies").forEach(playerIframe => {
+        new YT.Player(playerIframe.id);
+      })
+    }
+  }
+});

--- a/applications/common/frontend/src/components/index.scss
+++ b/applications/common/frontend/src/components/index.scss
@@ -50,3 +50,4 @@
 @use './Separator';
 @use './Table';
 @use './Accordion';
+@use './Video';

--- a/applications/common/frontend/src/components/index.ts
+++ b/applications/common/frontend/src/components/index.ts
@@ -31,7 +31,8 @@ import './Carousel/carousel';
 import './Search/search';
 import './Table/table';
 import './BlogTableOfContent/blogtableofcontent';
-import './Accordion/accordion'
+import './Accordion/accordion';
+import './Video/video.js';
 
 document.querySelectorAll('.navbar-item.has-dropdown').forEach((navbarItem) => {
   navbarItem.addEventListener('keydown', (event: KeyboardEvent) => {


### PR DESCRIPTION
Implement YT IFrame API option into Video component.

## Upgrade notes (if appropriate)
No content migration/modification is needed for the existing components as the related component property name is staying the same and the semantic of the default value also remains.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
