### PR TITLE
KYAN-321 Add default cookie consent state

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head-libs.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/page/head-libs.html
@@ -18,13 +18,25 @@
 
 <sly data-sly-use.model="pl.ds.kyanite.common.components.models.PageHeadLibsComponent"></sly>
 <sly data-sly-test="${wcmmode.isDisabled}">
-<!-- Google Tag Manager -->
-<script data-sly-test="${model.hasAnalyticsUrl}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.defer=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','${model.googleAnalyticsTrackingId @ context="text"}');</script>
-<!-- End Google Tag Manager -->
+  <!-- Google Tag Manager -->
+  <script data-sly-test="${model.hasAnalyticsUrl}">
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments)}
+    gtag('consent', 'default', {
+      'ad_storage': 'denied',
+      'analytics_storage': 'denied',
+      'personalization_storage': 'denied',
+      'functionality_storage': 'denied',
+      'security_storage': 'denied',
+      'ad_user_data': 'denied',
+      'ad_personalization': 'denied',
+    });
+    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.defer=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','${model.googleAnalyticsTrackingId @ context="text"}');</script>
+  <!-- End Google Tag Manager -->
 </sly>
 
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Applying advanced mode on our cookie consent setup: adding default configuration before the GTM script loads on the page.

## Description
Google Analytics 4 reported that content signals are missing from our sites, even though GTM shows that they are update through our injected cookie banner. Advanced consent mode means adding a default state by code in every consent category.
First and foremost the quality of our GTM setup will be better and also GA4 will probably detect these changes as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
