### PR TITLE
KYAN-322 Fix Contact Form input autofill colors

### DIFF
--- a/applications/common/frontend/src/components/ContactForm/ContactForm.scss
+++ b/applications/common/frontend/src/components/ContactForm/ContactForm.scss
@@ -87,4 +87,12 @@
       background-color: transparent;
     }
   }
+
+  input:-webkit-autofill,
+  input:-webkit-autofill:hover,
+  input:-webkit-autofill:focus,
+  input:-webkit-autofill:active {
+    -webkit-box-shadow: none;
+    transition: background-color 9999999999s ease-in-out 0s;
+  }
 }


### PR DESCRIPTION
We have a global rule setting black background to autofilled input to prevent the built in browser default behaviour.
With this change autofilled inputs will be transparent to create a consistent UI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
