### PR TITLE
KYAN-313 Remove simplebar for accessibility

### DIFF
--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogposttableofcontents/blogposttableofcontents.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/blogposttableofcontents/blogposttableofcontents.html
@@ -27,12 +27,14 @@
     <div class="blog-table-of-content">
       <label class="table-label">${model.title}</label>
         <sly data-sly-test.titles="${model.subTitles}">
-            <ul class="table-content-list" data-simplebar data-simplebar-auto-hide="false">
-            <sly data-sly-list.title="${titles}">
-                <sly data-sly-use.template="./templates/template-table-of-contents-element.html"
-                    data-sly-call="${template.title @ title=title}"></sly>
-            </sly>
-            </ul>
+            <div class="table-content-wrapper">
+              <ul class="table-content-list">
+                <sly data-sly-list.title="${titles}">
+                  <sly data-sly-use.template="./templates/template-table-of-contents-element.html"
+                       data-sly-call="${template.title @ title=title}"></sly>
+                </sly>
+              </ul>
+            </div>
         </sly>
         <sly data-sly-test="${model.showBackToTopButton}">
             <a class="table-content-button" data-sly-attribute.href="#">

--- a/applications/common/frontend/src/atomic-design-system/02-molecule/m.table-of-content/m.table-of-content.scss
+++ b/applications/common/frontend/src/atomic-design-system/02-molecule/m.table-of-content/m.table-of-content.scss
@@ -31,6 +31,31 @@
   .table-content-list {
     @extend .mb-4;
     @extend .pt-2;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+
+    > li:not(:last-child) {
+      margin-bottom: var(--spacing-3);
+    }
+
+    @supports (scrollbar-width: auto) {
+      scrollbar-color: var(--kyanite-gray-15) transparent;
+      scrollbar-width: thin;
+    }
+
+    @supports not (scrollbar-width: auto) {
+      &::-webkit-scrollbar-thumb {
+        background: var(--kyanite-gray-15);
+      }
+      &::-webkit-scrollbar-track {
+        background: transparent;
+      }
+      &::-webkit-scrollbar {
+        max-width: 10px;
+      }
+    }
 
     li {
       a.button {        
@@ -65,16 +90,5 @@
     @include link.a-animated-underline-link;
     color: var(--kyanite-gray-15) !important;
     display: inline-block;
-  }
-  .simplebar-scrollbar:before {
-    background: var(--kyanite-gray-15);
-  }
-  .simplebar-content { // first level list
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    > li:not(:last-child) {
-      margin-bottom: var(--spacing-3);
-    }
   }
 }

--- a/applications/common/frontend/src/atomic-design-system/02-molecule/m.table-of-content/m.table-of-content.scss
+++ b/applications/common/frontend/src/atomic-design-system/02-molecule/m.table-of-content/m.table-of-content.scss
@@ -40,20 +40,21 @@
       margin-bottom: var(--spacing-3);
     }
 
-    @supports (scrollbar-width: auto) {
+    @supports (scrollbar-color: auto) {
       scrollbar-color: var(--kyanite-gray-15) transparent;
       scrollbar-width: thin;
     }
 
-    @supports not (scrollbar-width: auto) {
+    @supports not (scrollbar-color: auto) {
       &::-webkit-scrollbar-thumb {
         background: var(--kyanite-gray-15);
+        border-radius: 4px;
       }
       &::-webkit-scrollbar-track {
         background: transparent;
       }
       &::-webkit-scrollbar {
-        max-width: 10px;
+        max-width: 7px;
       }
     }
 


### PR DESCRIPTION
Lighthouse reported accessibility issues related to our table of content component on blog pages. Simplebar lib caused it as it was creating additional div elements inside our ul element.
This PR aims to remove simplebar form the component while keeping the same look and feel of the UI.

The HTML markup change was necessary for the placement of the :before and :after pseudo elements in StreamX that created the fade effect.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
