### PR TITLE
KYAN-328 Add lazy loading for all image related components

### DIFF
--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogListComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogListComponent.java
@@ -42,6 +42,7 @@ import org.apache.sling.models.factory.ModelFactory;
 import org.jetbrains.annotations.Nullable;
 import pl.ds.kyanite.blogs.components.services.AuthorInfoResolverService;
 import pl.ds.kyanite.blogs.components.services.BlogArticleService;
+import pl.ds.kyanite.common.components.models.HasLoadingMode;
 import pl.ds.kyanite.common.components.utils.LinkUtil;
 import pl.ds.websight.pages.core.api.Page;
 import pl.ds.websight.pages.core.api.PageManager;
@@ -51,7 +52,7 @@ import pl.ds.websight.pages.core.api.PageManager;
     adaptables = {Resource.class},
     defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )
-public class BlogListComponent {
+public class BlogListComponent implements HasLoadingMode {
 
   @ValueMapValue
   @Getter
@@ -79,8 +80,6 @@ public class BlogListComponent {
   private List<BlogArticle> blogArticles;
 
   private final PageManager pageManager;
-
-  private String loadingMode;
 
   @Inject
   public BlogListComponent(@SlingObject ResourceResolver resourceResolver,
@@ -169,10 +168,5 @@ public class BlogListComponent {
     return pageAuthor != null
         && currentAuthor.getAuthorOwnerPath().equals(pageAuthor.getAuthorOwnerPath());
   }
-
-  public String getLoadingMode() {
-    return "high".equals(fetchPriority) ? "eager" : "lazy";
-  }
-
 }
 

--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogListComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/BlogListComponent.java
@@ -62,6 +62,11 @@ public class BlogListComponent {
   @Getter
   private String size;
 
+  @ValueMapValue
+  @Getter
+  @Default(values = "auto")
+  private String fetchPriority;
+
   public static final String JCR_CONTENT = "/jcr:content";
 
   private final ResourceResolver resourceResolver;
@@ -75,6 +80,7 @@ public class BlogListComponent {
 
   private final PageManager pageManager;
 
+  private String loadingMode;
 
   @Inject
   public BlogListComponent(@SlingObject ResourceResolver resourceResolver,
@@ -162,6 +168,10 @@ public class BlogListComponent {
     AuthorInfoModel pageAuthor = retrieveAuthorInfo(page);
     return pageAuthor != null
         && currentAuthor.getAuthorOwnerPath().equals(pageAuthor.getAuthorOwnerPath());
+  }
+
+  public String getLoadingMode() {
+    return "high".equals(fetchPriority) ? "eager" : "lazy";
   }
 
 }

--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/FeatureBlogArticleComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/FeatureBlogArticleComponent.java
@@ -63,6 +63,11 @@ public class FeatureBlogArticleComponent {
   @Getter
   private boolean isReversed;
 
+  @ValueMapValue
+  @Getter
+  @Default(values = "auto")
+  private String fetchPriority;
+
   @Getter
   private BlogArticleHeaderModel blogArticleHeader;
 
@@ -77,6 +82,8 @@ public class FeatureBlogArticleComponent {
   private final ModelFactory modelFactory;
   private final Resource resource;
   private final PageManager pageManager;
+
+  private String loadingMode;
 
   @Inject
   public FeatureBlogArticleComponent(
@@ -130,6 +137,10 @@ public class FeatureBlogArticleComponent {
         .stream()
         .findFirst()
         .orElse(null);
+  }
+
+  public String getLoadingMode() {
+    return "high".equals(fetchPriority) ? "eager" : "lazy";
   }
 
 }

--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/FeatureBlogArticleComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/FeatureBlogArticleComponent.java
@@ -34,6 +34,7 @@ import org.apache.sling.models.factory.ModelFactory;
 import pl.ds.kyanite.blogs.components.exceptions.AuthorInfoResolvingException;
 import pl.ds.kyanite.blogs.components.services.AuthorInfoResolverService;
 import pl.ds.kyanite.blogs.components.services.BlogArticleService;
+import pl.ds.kyanite.common.components.models.HasLoadingMode;
 import pl.ds.kyanite.common.components.utils.LinkUtil;
 import pl.ds.websight.pages.core.api.Page;
 import pl.ds.websight.pages.core.api.PageManager;
@@ -42,7 +43,7 @@ import pl.ds.websight.pages.core.api.PageManager;
     adaptables = {Resource.class},
     defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )
-public class FeatureBlogArticleComponent {
+public class FeatureBlogArticleComponent implements HasLoadingMode {
 
   public static final String CONTENT = "/content";
   public static final String JCR_CONTENT = "/jcr:content";
@@ -82,8 +83,6 @@ public class FeatureBlogArticleComponent {
   private final ModelFactory modelFactory;
   private final Resource resource;
   private final PageManager pageManager;
-
-  private String loadingMode;
 
   @Inject
   public FeatureBlogArticleComponent(
@@ -138,10 +137,5 @@ public class FeatureBlogArticleComponent {
         .findFirst()
         .orElse(null);
   }
-
-  public String getLoadingMode() {
-    return "high".equals(fetchPriority) ? "eager" : "lazy";
-  }
-
 }
 

--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/QuoteComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/QuoteComponent.java
@@ -20,9 +20,11 @@ import javax.inject.Inject;
 import lombok.Getter;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
+import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
 import pl.ds.kyanite.common.components.models.layouts.TemplateHandler;
 import pl.ds.kyanite.common.components.utils.LinkUtil;
 
@@ -47,7 +49,14 @@ public class QuoteComponent implements Quote, TemplateHandler {
   @Inject
   private String authorPhotoPath;
 
+  @ValueMapValue
+  @Getter
+  @Default(values = "auto")
+  private String fetchPriority;
+
   private final ResourceResolver resourceResolver;
+
+  private String loadingMode;
 
   @Inject
   public QuoteComponent(
@@ -59,6 +68,10 @@ public class QuoteComponent implements Quote, TemplateHandler {
   @Override
   public String getAuthorPhoto() {
     return LinkUtil.handleLink(authorPhotoPath, resourceResolver);
+  }
+
+  public String getLoadingMode() {
+    return "high".equals(fetchPriority) ? "eager" : "lazy";
   }
 
 }

--- a/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/QuoteComponent.java
+++ b/applications/blogs/backend/src/main/java/pl/ds/kyanite/blogs/components/models/QuoteComponent.java
@@ -25,6 +25,7 @@ import org.apache.sling.models.annotations.DefaultInjectionStrategy;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import pl.ds.kyanite.common.components.models.HasLoadingMode;
 import pl.ds.kyanite.common.components.models.layouts.TemplateHandler;
 import pl.ds.kyanite.common.components.utils.LinkUtil;
 
@@ -32,7 +33,7 @@ import pl.ds.kyanite.common.components.utils.LinkUtil;
     adaptables = { Resource.class },
     defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL
 )
-public class QuoteComponent implements Quote, TemplateHandler {
+public class QuoteComponent implements Quote, TemplateHandler, HasLoadingMode {
 
   @Inject
   @Getter
@@ -56,8 +57,6 @@ public class QuoteComponent implements Quote, TemplateHandler {
 
   private final ResourceResolver resourceResolver;
 
-  private String loadingMode;
-
   @Inject
   public QuoteComponent(
       @SlingObject ResourceResolver resourceResolver
@@ -69,9 +68,4 @@ public class QuoteComponent implements Quote, TemplateHandler {
   public String getAuthorPhoto() {
     return LinkUtil.handleLink(authorPhotoPath, resourceResolver);
   }
-
-  public String getLoadingMode() {
-    return "high".equals(fetchPriority) ? "eager" : "lazy";
-  }
-
 }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/bloglist.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/bloglist.html
@@ -22,7 +22,8 @@
       <a href="${item.link}" class="column is-4-desktop article-thumbnail">
         <div class="has-text-centered image-hero">
           <img data-sly-test.heroImage="${item.blogArticleHeader.heroImage}" src="${heroImage}"
-               alt="${item.blogArticleHeader.heroImageAlt}" loading="lazy">
+               alt="${item.blogArticleHeader.heroImageAlt}"
+               loading="${model.loadingMode}" fetchpriority="${model.fetchPriority}">
         </div>
         <div class="content">
           <div class="content-info">

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/dialog/.content.json
@@ -37,6 +37,27 @@
             }
           }
         }
+      },
+      "fetchPriority" : {
+        "sling:resourceType": "wcm/dialogs/components/select",
+        "name": "fetchPriority",
+        "label": "Blog Images Fetch Priority",
+        "description": "Prioritize images on page load. Setting high priority to multiple images on a page may reduce its effect.",
+        "low": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Low",
+          "value": "low"
+        },
+        "auto": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Auto",
+          "value": "auto"
+        },
+        "high": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "High",
+          "value": "high"
+        }
       }
     }
   }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/template/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/template/.content.json
@@ -4,5 +4,6 @@
   "author": {
     "jcr:primaryType": "nt:unstructured",
     "authorInfoSource": "parentPage"
-  }
+  },
+  "fetchPriority": false
 }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/template/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/bloglist/template/.content.json
@@ -5,5 +5,5 @@
     "jcr:primaryType": "nt:unstructured",
     "authorInfoSource": "parentPage"
   },
-  "fetchPriority": false
+  "fetchPriority": "auto"
 }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/dialog/.content.json
@@ -32,6 +32,27 @@
         "checkedByDefault": false,
         "label": "The position of the columns is reversed",
         "description": "If you want the reverse the position of the columns."
+      },
+      "fetchPriority" : {
+        "sling:resourceType": "wcm/dialogs/components/select",
+        "name": "fetchPriority",
+        "label": "Blog Image Fetch Priority",
+        "description": "Prioritize image on page load. Setting high priority to multiple images on a page may reduce its effect.",
+        "low": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Low",
+          "value": "low"
+        },
+        "auto": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "Auto",
+          "value": "auto"
+        },
+        "high": {
+          "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+          "label": "High",
+          "value": "high"
+        }
       }
     }
   }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/featuredblogarticle.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/featuredblogarticle.html
@@ -23,7 +23,8 @@
         <div class="column">
           <figure class="image-hero">
             <img data-sly-test.heroImage="${article.heroImage}" src="${heroImage}"
-                 alt="${article.heroImageAlt}">
+                 alt="${article.heroImageAlt}"
+                 loading="${model.loadingMode}" fetchpriority="${model.fetchPriority}">
           </figure>
         </div>
         <div class="column">

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/template/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/template/.content.json
@@ -1,4 +1,5 @@
 {
   "jcr:primaryType": "nt:unstructured",
-  "link": "/content"
+  "link": "/content",
+  "fetchPriority": false
 }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/template/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/featuredblogarticle/template/.content.json
@@ -1,5 +1,5 @@
 {
   "jcr:primaryType": "nt:unstructured",
   "link": "/content",
-  "fetchPriority": false
+  "fetchPriority": "auto"
 }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/quote/dialog/.content.json
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/quote/dialog/.content.json
@@ -79,6 +79,30 @@
           "ws:disallowedContext": [
             "edit:panel"
           ]
+        },
+        "fetchPriority" : {
+          "sling:resourceType": "wcm/dialogs/components/select",
+          "name": "fetchPriority",
+          "label": "Blog Image Fetch Priority",
+          "description": "Prioritize image on page load. Setting high priority to multiple images on a page may reduce its effect.",
+          "low": {
+            "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+            "label": "Low",
+            "value": "low"
+          },
+          "auto": {
+            "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+            "label": "Auto",
+            "value": "auto"
+          },
+          "high": {
+            "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+            "label": "High",
+            "value": "high"
+          },
+          "ws:disallowedContext": [
+            "edit:panel"
+          ]
         }
       }
     }

--- a/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/quote/templates/template-default.html
+++ b/applications/blogs/backend/src/main/resources/libs/kyanite/blogs/components/quote/templates/template-default.html
@@ -29,7 +29,8 @@
           <p class="image is-64x64">
             <img src="${authorPhoto}"
                  alt="${model.authorPhotoAlt}"
-                 class="is-rounded"/>
+                 class="is-rounded"
+                 loading="${model.loadingMode}" fetchpriority="${model.fetchPriority}"/>
           </p>
         </figure>
       </sly>

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/HasLoadingMode.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/HasLoadingMode.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2025 Dynamic Solutions
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pl.ds.kyanite.common.components.models;
+
+public interface HasLoadingMode {
+
+  String getFetchPriority();
+
+  default String getLoadingMode() {
+    return "high".equals(getFetchPriority()) ? "eager" : "lazy";
+  }
+
+}

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/ImageComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/ImageComponent.java
@@ -39,7 +39,7 @@ import pl.ds.kyanite.common.components.services.SvgImageService;
 import pl.ds.kyanite.common.components.utils.LinkUtil;
 
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
-public class ImageComponent {
+public class ImageComponent implements HasLoadingMode {
 
   private static final String NONE_STYLES_TYPE = "none";
   private static final String SVG_MIME_TYPE = "image/svg+xml";
@@ -144,8 +144,6 @@ public class ImageComponent {
 
   private boolean isInternal;
 
-  private String loadingMode;
-
   @PostConstruct
   private void init() {
     if (Objects.nonNull(assetReference)) {
@@ -221,9 +219,5 @@ public class ImageComponent {
   private boolean isVideo(String link) {
     String mimeType = URLConnection.guessContentTypeFromName(link);
     return mimeType != null && mimeType.startsWith("video");
-  }
-
-  public String getLoadingMode() {
-    return "high".equals(fetchPriority) ? "eager" : "lazy";
   }
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
@@ -59,6 +59,12 @@ public class VideoComponent {
   @Getter
   private boolean hasThumbnail;
 
+  @ValueMapValue
+  @Getter
+  @Default(values = "auto")
+  private String fetchPriority;
+
+  private String loadingMode;
 
   @ValueMapValue
   @Default(values = StringUtils.EMPTY)
@@ -162,6 +168,10 @@ public class VideoComponent {
 
   public String getThumbnail() {
     return LinkUtil.handleLink(thumbnail, resource.getResourceResolver());
+  }
+
+  public String getLoadingMode() {
+    return "high".equals(fetchPriority) ? "eager" : "lazy";
   }
 
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/VideoComponent.java
@@ -36,7 +36,7 @@ import pl.ds.kyanite.common.components.utils.LinkUtil;
 import pl.ds.kyanite.common.components.utils.VideoLinkParser;
 
 @Model(adaptables = Resource.class, defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL)
-public class VideoComponent {
+public class VideoComponent implements HasLoadingMode {
 
   @ValueMapValue
   @Default(values = StringUtils.EMPTY)
@@ -63,8 +63,6 @@ public class VideoComponent {
   @Getter
   @Default(values = "auto")
   private String fetchPriority;
-
-  private String loadingMode;
 
   @ValueMapValue
   @Default(values = StringUtils.EMPTY)
@@ -169,9 +167,4 @@ public class VideoComponent {
   public String getThumbnail() {
     return LinkUtil.handleLink(thumbnail, resource.getResourceResolver());
   }
-
-  public String getLoadingMode() {
-    return "high".equals(fetchPriority) ? "eager" : "lazy";
-  }
-
 }

--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/background/DefaultComponentWithBackground.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/background/DefaultComponentWithBackground.java
@@ -26,10 +26,11 @@ import org.apache.sling.api.resource.Resource;
 import org.apache.sling.models.annotations.Default;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.ValueMapValue;
+import pl.ds.kyanite.common.components.models.HasLoadingMode;
 import pl.ds.kyanite.common.components.models.ImageComponent;
 
 @Model(adaptables = Resource.class, defaultInjectionStrategy = OPTIONAL)
-public class DefaultComponentWithBackground {
+public class DefaultComponentWithBackground implements HasLoadingMode {
 
   @Inject
   private ImageComponent desktopBackgroundImage;
@@ -60,8 +61,6 @@ public class DefaultComponentWithBackground {
   @ValueMapValue
   @Getter
   private String height;
-
-  private String loadingMode;
 
   public String getDesktopBackgroundImage() {
     return getBackgroundImage(desktopBackgroundImage);
@@ -109,9 +108,4 @@ public class DefaultComponentWithBackground {
 
     return image.getAssetReference();
   }
-
-  public String getLoadingMode() {
-    return "high".equals(fetchPriority) ? "eager" : "lazy";
-  }
-
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/common/image/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/common/image/.content.json
@@ -1,5 +1,26 @@
 {
   "sling:resourceType": "wcm/dialogs/components/container",
+  "fetchPriority" : {
+    "sling:resourceType": "wcm/dialogs/components/select",
+    "name": "image/fetchPriority",
+    "label": "Image Fetch Priority",
+    "description": "Prioritize this image on page load. Setting high priority to multiple images on a page may reduce its effect.",
+    "low": {
+      "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+      "label": "Low",
+      "value": "low"
+    },
+    "auto": {
+      "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+      "label": "Auto",
+      "value": "auto"
+    },
+    "high": {
+      "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+      "label": "High",
+      "value": "high"
+    }
+  },
   "alt": {
     "sling:resourceType": "wcm/dialogs/components/textfield",
     "name": "image/alt",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/template.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/template.html
@@ -25,7 +25,7 @@
       </sly>
 
       <img src="${model.image.assetReference}" width="${model.image.width}" height="${model.image.height}" alt="${model.image.alt}"
-           loading="${model.loadingMode}" fetchpriority="${model.fetchPriority}"/>
+           loading="${model.image.loadingMode}" fetchpriority="${model.image.fetchPriority}"/>
     </picture>
   </figure>
 </template>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/template/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/template/.content.json
@@ -1,13 +1,13 @@
 {
   "jcr:primaryType": "nt:unstructured",
   "padding": "p-0",
-  "fetchPriority": "auto",
   "cardcontent": {
     "jcr:primaryType": "nt:unstructured",
     "sling:resourceType": "kyanite/common/components/card/cardcontent"
   },
   "image": {
     "jcr:primaryType": "nt:unstructured",
-    "style": "is-4by3"
+    "style": "is-4by3",
+    "fetchPriority": "auto"
   }
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/section.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/section/section.html
@@ -33,7 +33,7 @@
       </sly>
 
       <img width="${model.width}" height="${model.height}" class="img-as-bg" src="${model.desktopImage}"
-           alt="${model.alt}" fetchpriority="${model.fetchPriority}">
+           alt="${model.alt}" fetchpriority="${model.fetchPriority}" loading="${model.loadingMode}">
     </picture>
     <sly data-sly-repeat.paragraph="${model.children}"
          data-sly-resource="${paragraph.path @ resourceType=paragraph.resourceType}"></sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/dialog/.content.json
@@ -93,15 +93,39 @@
         "name": "hasThumbnail",
         "label": "Thumbnail"
       },
-      "customThumbnail": {
-        "sling:resourceType": "wcm/dialogs/components/assetreference",
-        "rootPath": "/content",
-        "mimeTypes": [
-          "image/*"
-        ],
-        "name": "thumbnail",
-        "description": "Choose a Thumbnail",
-        "label": "Thumbnail",
+      "thumbnailContainer" : {
+        "sling:resourceType": "wcm/dialogs/components/container",
+        "fetchPriority" : {
+          "sling:resourceType": "wcm/dialogs/components/select",
+          "name": "fetchPriority",
+          "label": "Thumbnail Image Fetch Priority",
+          "description": "Prioritize this image on page load. Setting high priority to multiple images on a page may reduce its effect.",
+          "low": {
+            "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+            "label": "Low",
+            "value": "low"
+          },
+          "auto": {
+            "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+            "label": "Auto",
+            "value": "auto"
+          },
+          "high": {
+            "sling:resourceType": "wcm/dialogs/components/select/selectitem",
+            "label": "High",
+            "value": "high"
+          }
+        },
+        "customThumbnail": {
+          "sling:resourceType": "wcm/dialogs/components/assetreference",
+          "rootPath": "/content",
+          "mimeTypes": [
+            "image/*"
+          ],
+          "name": "thumbnail",
+          "description": "Choose a Thumbnail",
+          "label": "Thumbnail"
+        },
         "ws:display": {
           "condition": {
             "sourceName": "hasThumbnail",

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/template/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/template/.content.json
@@ -1,5 +1,6 @@
 {
   "jcr:primaryType": "nt:unstructured",
   "source": "video",
-  "hasThumbnail": true
+  "hasThumbnail": true,
+  "fetchPriority": "auto"
 }

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/video.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/video/video.html
@@ -32,7 +32,8 @@
     </sly>
     <sly data-sly-test=${!model.isVideo}>
       <sly data-sly-test="${model.hasThumbnail}">
-        <img class="iframe-thumbnail" src="${model.thumbnail}" alt="Thumbnail image">
+        <img class="iframe-thumbnail" src="${model.thumbnail}" alt="Thumbnail image"
+             loading="${model.loadingMode}" fetchpriority="${model.fetchPriority}">
       </sly>
       <sly data-sly-test.link="${[model.src,model.shareLinkParameters] @ join = '?'}"></sly>
       <iframe id="${model.youtubeIframeId}"


### PR DESCRIPTION
Adding lazy loading configuration to components containing images. As discussed with Kasia, by default all images will have the `loading=lazy` attribute and authors will have the option to override that manually for images above the fold.

After the deployment of these changes, all pages have to be manually checked before publication and handle image related component instances.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
