### PR TITLE
KYAN-336 Fix megamenu paddings in mobile view

### DIFF
--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmegadropdown/navbarmegadropdown.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmegadropdown/navbarmegadropdown.html
@@ -28,7 +28,7 @@
         <div class="columns is-desktop">
           <sly data-sly-list.column="${model.dropdownColumns}">
             <sly data-sly-test="${!column.hideColumn && column.type == 'text'}">
-              <div class="column text-column ${column.sections.size > 0 ? '' : 'empty-column'} ${column.colSizeClass}">
+              <div class="column text-column ${column.sections.size > 0 ? '' : 'p-0-below-lg'} ${column.colSizeClass}">
                 <sly data-sly-list.section="${column.sections}">
                   <span class="navbar-section">
                     ${section.label}
@@ -47,7 +47,7 @@
               </div>
             </sly>
             <sly data-sly-test="${!column.hideColumn && column.type == 'highlights'}">
-              <div class="column highlights-column ${column.highlights.size > 0 ? '' : 'empty-column'} ${column.colSizeClass}">
+              <div class="column highlights-column ${column.highlights.size > 0 ? '' : 'p-0-below-lg'} ${column.colSizeClass}">
                 <sly data-sly-list.highlight="${column.highlights}">
                   <a data-sly-test="${highlight.url}" class="navbar-item" href="${highlight.url}" target="${highlight.isExternalUrl ? '_blank' : ''}">
                     ${highlight.label}

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmegadropdown/navbarmegadropdown.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/navbar/navbarmegadropdown/navbarmegadropdown.html
@@ -28,7 +28,7 @@
         <div class="columns is-desktop">
           <sly data-sly-list.column="${model.dropdownColumns}">
             <sly data-sly-test="${!column.hideColumn && column.type == 'text'}">
-              <div class="column text-column ${column.colSizeClass}">
+              <div class="column text-column ${column.sections.size > 0 ? '' : 'empty-column'} ${column.colSizeClass}">
                 <sly data-sly-list.section="${column.sections}">
                   <span class="navbar-section">
                     ${section.label}
@@ -47,7 +47,7 @@
               </div>
             </sly>
             <sly data-sly-test="${!column.hideColumn && column.type == 'highlights'}">
-              <div class="column highlights-column ${column.colSizeClass}">
+              <div class="column highlights-column ${column.highlights.size > 0 ? '' : 'empty-column'} ${column.colSizeClass}">
                 <sly data-sly-list.highlight="${column.highlights}">
                   <a data-sly-test="${highlight.url}" class="navbar-item" href="${highlight.url}" target="${highlight.isExternalUrl ? '_blank' : ''}">
                     ${highlight.label}

--- a/applications/common/frontend/src/atomic-design-system/03-organism/o.navbar/o.navbar.scss
+++ b/applications/common/frontend/src/atomic-design-system/03-organism/o.navbar/o.navbar.scss
@@ -16,6 +16,7 @@
  * -->
  */
 
+@use 'sass:map';
 @use 'src/atomic-design-system/00-token/t.spacing';
 @use 'src/atomic-design-system/00-token/t.breakpoint' as breakpoint;
 @use 'src/atomic-design-system/01-atom/a.animated-underline-link' as link;
@@ -297,6 +298,12 @@
     }
     .navbar-section {
       color: var(--kyanite-gray-60);
+    }
+    
+    @media (width < map.get(breakpoint.$map_t-breakpoints-px, large)) {
+      .empty-column {
+        padding: 0;
+      }
     }
   }
 

--- a/applications/common/frontend/src/atomic-design-system/03-organism/o.navbar/o.navbar.scss
+++ b/applications/common/frontend/src/atomic-design-system/03-organism/o.navbar/o.navbar.scss
@@ -301,7 +301,7 @@
     }
     
     @media (width < map.get(breakpoint.$map_t-breakpoints-px, large)) {
-      .empty-column {
+      .p-0-below-lg {
         padding: 0;
       }
     }


### PR DESCRIPTION
## Description
Originally megamenu columns had a default padding value added, even to columns that were empty.
On mobile view this created extra, unnecessary spaces between menu elements.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [ ] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
