### PR TITLE
KYAN-334 Add anchor name property to card component

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/CardComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/CardComponent.java
@@ -92,6 +92,11 @@ public class CardComponent implements ComponentWithBackground {
 
   @Inject
   @Getter
+  @Default(values = StringUtils.EMPTY)
+  private String anchorName;
+
+  @Inject
+  @Getter
   private boolean openInNewTab;
 
   @SlingObject

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/card.html
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/card.html
@@ -70,7 +70,11 @@
     </sly>
 
     <sly data-sly-test="${model.type == 'anchor' && model.anchorUrl}">
-      <a class="card-redirect-anchor" href="${model.anchorUrl}" target="${model.openInNewTab ? '_blank' : ''}"></a>
+      <a class="card-redirect-anchor"
+         href="${model.anchorUrl}"
+         target="${model.openInNewTab ? '_blank' : ''}"
+         aria-label="${model.anchorName}">
+      </a>
     </sly>
   </div>
 </sly>

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/card/dialog/.content.json
@@ -49,6 +49,12 @@
           "name": "anchorUrl",
           "label": "Anchor URL"
         },
+        "anchorName": {
+          "sling:resourceType": "wcm/dialogs/components/textfield",
+          "name": "anchorName",
+          "label": "Anchor Name",
+          "description": "Provide a discernible name to the anchor for accessibility purposes."
+        },
         "openInNewTab": {
           "sling:resourceType": "wcm/dialogs/components/toggle",
           "name": "openInNewTab",


### PR DESCRIPTION
## Description
As per the Lighthouse analysis our Cards which are treated as anchors are missing a discernible name. This PR adds the option to authors to fill in an anchor name for each card component.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.
