### PR TITLE
KYAN-337 Add option to invert column order for mobile

### DIFF
--- a/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/columns/ColumnsComponent.java
+++ b/applications/common/backend/src/main/java/pl/ds/kyanite/common/components/models/columns/ColumnsComponent.java
@@ -77,6 +77,10 @@ public class ColumnsComponent {
 
   @Getter
   @Inject
+  private boolean invertMobileColumnOrder;
+
+  @Getter
+  @Inject
   private String[] classes;
 
   @PostConstruct
@@ -99,6 +103,10 @@ public class ColumnsComponent {
 
     if (isCentered) {
       classList.add("is-centered");
+    }
+
+    if (invertMobileColumnOrder) {
+      classList.add("invert-column-order-mobile");
     }
 
     classList.add(columnsActivationLevel);

--- a/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/dialog/.content.json
+++ b/applications/common/backend/src/main/resources/libs/kyanite/common/components/columns/dialog/.content.json
@@ -77,6 +77,11 @@
           "sourceName": "isCustomGapLevel",
           "values": true
         }}
+      },
+      "invertMobileColumnOrder": {
+        "sling:resourceType": "wcm/dialogs/components/toggle",
+        "name": "invertMobileColumnOrder",
+        "label": "Invert column order for mobile view"
       }
     }
   }

--- a/applications/common/frontend/src/components/Column/Column.scss
+++ b/applications/common/frontend/src/components/Column/Column.scss
@@ -16,7 +16,16 @@
  * -->
  */
 
+@use 'sass:map';
 @use 'src/atomic-design-system/00-token/t.position' as position;
+@use 'src/atomic-design-system/00-token/t.breakpoint' as breakpoint;
+
+@media (width < map.get(breakpoint.$map_t-breakpoints-px, medium)) {
+  .columns.invert-column-order-mobile {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+}
 
 .column {
   &.sticky-container {


### PR DESCRIPTION
## Description
To provide a consistent UX on mobile, left-right and right-left sections should be able to configure specifically for mobile. These layouts are build on columns so this PR extends it. Issue described in: [WSIO-1339](https://teamds.atlassian.net/browse/WSIO-1339)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue) labeled with `bug`
- [x] New feature (non-breaking change which adds functionality) labeled with `enhancement`
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code standards](../CONTRIBUTING.md) of this project.
- [ ] My change requires updating the documentation. I have updated the documentation accordingly.


[WSIO-1339]: https://teamds.atlassian.net/browse/WSIO-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ